### PR TITLE
Redefine OIDC nonce login

### DIFF
--- a/scouting-openid-connect.php
+++ b/scouting-openid-connect.php
@@ -133,7 +133,7 @@ add_action('wp_login', [$scouting_oidc_auth, 'scouting_oidc_auth_login_redirect'
 // Add logout redirect
 add_action('wp_logout', [$scouting_oidc_auth, 'scouting_oidc_auth_logout_redirect']);
 
-// Daily cleanup for logs older than 30 days.
+// Daily cleanup for logs older than the configured retention period.
 add_action(CronJobs::CLEANUP_CRON_HOOK, [CronJobs::class, 'scouting_oidc_logger_cleanup_old_logs']);
 
 // Ensure log cleanup schedule exists during runtime.

--- a/src/auth/Auth.php
+++ b/src/auth/Auth.php
@@ -139,7 +139,7 @@ class Auth {
             // Return login URL with hint
             return ErrorHandler::login_error_url('init', $hint, 'init_error');
         }
-        return esc_url($this->scouting_oidc_auth_login_url());
+        return esc_url($login_url);
     }
 
     /**
@@ -210,8 +210,8 @@ class Auth {
             ErrorHandler::redirect_to_login_error('error', __('Code is missing', 'scouting-openid-connect'), 'code_missing');
         }
 
-        // Save nonce before retrieveTokens clears session state, so validateTokens can compare it
-        $stored_nonce = $this->oidc_client->getNonce();
+        // Fetch nonce bound to this specific state before retrieveTokens clears session data
+        $stored_nonce = $this->oidc_client->getNonceForState($state);
 
         // Retrieve tokens from the OpenID Connect server using the validated 'code' parameter
         $this->oidc_client->retrieveTokens($param_code, $state);

--- a/src/auth/Auth.php
+++ b/src/auth/Auth.php
@@ -203,11 +203,18 @@ class Auth {
             ErrorHandler::redirect_to_login_error('error', __('Code is missing', 'scouting-openid-connect'), 'code_missing');
         }
 
+        // Validate that the 'code' parameter is a non-empty string
+        $param_code = is_string($param_code ?? null) ? trim($param_code) : '';
+        if ($param_code === '') {
+            $this->oidc_client->unsetStatesAndNonce();
+            ErrorHandler::redirect_to_login_error('error', __('Code is missing', 'scouting-openid-connect'), 'code_missing');
+        }
+
         // Save nonce before retrieveTokens clears session state, so validateTokens can compare it
         $stored_nonce = $this->oidc_client->getNonce();
 
-        // Retrieve tokens from the OpenID Connect server and sanitize the 'code' parameter
-        $this->oidc_client->retrieveTokens($param_code ?? '', $state);
+        // Retrieve tokens from the OpenID Connect server using the validated 'code' parameter
+        $this->oidc_client->retrieveTokens($param_code, $state);
 
         // Validate the ID token, passing the stored nonce for claim verification
         $user_json_encoded = $this->oidc_client->validateTokens($stored_nonce);

--- a/src/auth/Auth.php
+++ b/src/auth/Auth.php
@@ -158,12 +158,6 @@ class Auth {
             return;
         }
 
-        // Check if nonce is valid with wp_verify_nonce
-        if (wp_verify_nonce($this->oidc_client->getNonce())) {
-            $this->oidc_client->unsetStatesAndNonce();
-            ErrorHandler::redirect_to_login_error('error', __('Nonce is invalid', 'scouting-openid-connect'), 'nonce_invalid');
-        }
-
         // Handle error callback parameters and forward them to wp-login.
         if (isset($_GET['error_description'], $_GET['hint'])) {
             $this->oidc_client->unsetStatesAndNonce();
@@ -200,11 +194,14 @@ class Auth {
             ErrorHandler::redirect_to_login_error('error', __('Code is missing', 'scouting-openid-connect'), 'code_missing');
         }
 
+        // Save nonce before retrieveTokens clears session state, so validateTokens can compare it
+        $stored_nonce = $this->oidc_client->getNonce();
+
         // Retrieve tokens from the OpenID Connect server and sanitize the 'code' parameter
         $this->oidc_client->retrieveTokens(sanitize_text_field(wp_unslash($_GET['code'])), $state);
 
-        // Validate the ID token
-        $user_json_encoded = $this->oidc_client->validateTokens();
+        // Validate the ID token, passing the stored nonce for claim verification
+        $user_json_encoded = $this->oidc_client->validateTokens($stored_nonce);
 
         // Create a new User object
         $user = new User($user_json_encoded);
@@ -238,11 +235,6 @@ class Auth {
         // Check if user is logged in
         if (!is_login()) {
             return $message;
-        }
-
-        // Check if nonce is valid
-        if (wp_verify_nonce($this->oidc_client->getNonce())) {
-            $this->oidc_client->unsetStatesAndNonce();
         }
 
         // Check if error_description, hint, and message are set in the URL
@@ -419,11 +411,6 @@ class Auth {
         $response_type = 'code';
         $scopes = array_map('sanitize_text_field', explode(" ", get_option('scouting_oidc_scopes')));
 
-        // Check if nonce is valid
-        if (wp_verify_nonce($this->oidc_client->getNonce())) {
-            $this->oidc_client->unsetStatesAndNonce();
-        }
-        
         // Check if error_description, hint, and message are set in the URL
         if (isset($_GET['error_description'], $_GET['hint'])) {
             $error_description = sanitize_text_field(wp_unslash($_GET['error_description']));

--- a/src/auth/Auth.php
+++ b/src/auth/Auth.php
@@ -167,12 +167,12 @@ class Auth {
         $param_code_raw = filter_input(INPUT_GET, 'code', FILTER_UNSAFE_RAW);
 
         // All parameters are sanitized as they may contain untrusted data.
-        $param_error_description = is_string($param_error_description_raw) ? sanitize_text_field(wp_unslash($param_error_description_raw)) : null;
-        $param_hint = is_string($param_hint_raw) ? sanitize_text_field(wp_unslash($param_hint_raw)) : null;
-        $param_error = is_string($param_error_raw) ? sanitize_text_field(wp_unslash($param_error_raw)) : null;
-        $param_message = is_string($param_message_raw) ? sanitize_text_field(wp_unslash($param_message_raw)) : null;
-        $param_state = is_string($param_state_raw) ? sanitize_text_field(wp_unslash($param_state_raw)) : null;
-        $param_code = is_string($param_code_raw) ? sanitize_text_field(wp_unslash($param_code_raw)) : null;
+        $param_error_description = is_string($param_error_description_raw) ? sanitize_text_field($param_error_description_raw) : null;
+        $param_hint = is_string($param_hint_raw) ? sanitize_text_field($param_hint_raw) : null;
+        $param_error = is_string($param_error_raw) ? sanitize_text_field($param_error_raw) : null;
+        $param_message = is_string($param_message_raw) ? sanitize_text_field($param_message_raw) : null;
+        $param_state = is_string($param_state_raw) ? sanitize_text_field($param_state_raw) : null;
+        $param_code = is_string($param_code_raw) ? sanitize_text_field($param_code_raw) : null;
 
         // Handle error callback parameters and forward them to wp-login.
         if (filter_has_var(INPUT_GET, 'error_description') && filter_has_var(INPUT_GET, 'hint')) {

--- a/src/auth/Auth.php
+++ b/src/auth/Auth.php
@@ -158,29 +158,38 @@ class Auth {
             return;
         }
 
+        // All raw $_GET reads collected here.
+        $param_error_description_raw = filter_input(INPUT_GET, 'error_description', FILTER_UNSAFE_RAW);
+        $param_hint_raw = filter_input(INPUT_GET, 'hint', FILTER_UNSAFE_RAW);
+        $param_error_raw = filter_input(INPUT_GET, 'error', FILTER_UNSAFE_RAW);
+        $param_message_raw = filter_input(INPUT_GET, 'message', FILTER_UNSAFE_RAW);
+        $param_state_raw = filter_input(INPUT_GET, 'state', FILTER_UNSAFE_RAW);
+        $param_code_raw = filter_input(INPUT_GET, 'code', FILTER_UNSAFE_RAW);
+
+        // All parameters are sanitized as they may contain untrusted data.
+        $param_error_description = is_string($param_error_description_raw) ? sanitize_text_field(wp_unslash($param_error_description_raw)) : null;
+        $param_hint = is_string($param_hint_raw) ? sanitize_text_field(wp_unslash($param_hint_raw)) : null;
+        $param_error = is_string($param_error_raw) ? sanitize_text_field(wp_unslash($param_error_raw)) : null;
+        $param_message = is_string($param_message_raw) ? sanitize_text_field(wp_unslash($param_message_raw)) : null;
+        $param_state = is_string($param_state_raw) ? sanitize_text_field(wp_unslash($param_state_raw)) : null;
+        $param_code = is_string($param_code_raw) ? sanitize_text_field(wp_unslash($param_code_raw)) : null;
+
         // Handle error callback parameters and forward them to wp-login.
-        if (isset($_GET['error_description'], $_GET['hint'])) {
+        if (filter_has_var(INPUT_GET, 'error_description') && filter_has_var(INPUT_GET, 'hint')) {
             $this->oidc_client->unsetStatesAndNonce();
 
-            $error_description = sanitize_text_field(wp_unslash($_GET['error_description']));
-            $hint = sanitize_text_field(wp_unslash($_GET['hint']));
-            $error = isset($_GET['error'])
-                ? sanitize_text_field(wp_unslash($_GET['error']))
-                : null;
-            $message = isset($_GET['message'])
-                ? sanitize_text_field(wp_unslash($_GET['message']))
-                : ($error ?? 'error');
+            $message = $param_message ?? ($param_error ?? 'error');
 
-            ErrorHandler::redirect_to_login_error($error_description, $hint, $message, $error);
+            ErrorHandler::redirect_to_login_error($param_error_description ?? '', $param_hint ?? '', $message, $param_error);
         }
 
         // Check if 'state' parameter is set in the URL
-        if (!isset($_GET['state'])) {
+        if (!filter_has_var(INPUT_GET, 'state')) {
             return;
         }
 
         // Verify state parameter for security
-        $state = sanitize_text_field(wp_unslash($_GET['state']));
+        $state = $param_state ?? '';
 
         // If the state is invalid, unset states and nonce, then redirect to login page with an error message
         if (!$this->oidc_client->hasState($state)) {
@@ -189,7 +198,7 @@ class Auth {
         }
 
         // Check if 'code' parameter is set in the URL
-        if (!isset($_GET['code'])) {
+        if (!filter_has_var(INPUT_GET, 'code')) {
             $this->oidc_client->unsetStatesAndNonce();
             ErrorHandler::redirect_to_login_error('error', __('Code is missing', 'scouting-openid-connect'), 'code_missing');
         }
@@ -198,7 +207,7 @@ class Auth {
         $stored_nonce = $this->oidc_client->getNonce();
 
         // Retrieve tokens from the OpenID Connect server and sanitize the 'code' parameter
-        $this->oidc_client->retrieveTokens(sanitize_text_field(wp_unslash($_GET['code'])), $state);
+        $this->oidc_client->retrieveTokens($param_code ?? '', $state);
 
         // Validate the ID token, passing the stored nonce for claim verification
         $user_json_encoded = $this->oidc_client->validateTokens($stored_nonce);
@@ -238,13 +247,19 @@ class Auth {
         }
 
         // Check if error_description, hint, and message are set in the URL
-        if (!isset($_GET['error_description'], $_GET['hint'], $_GET['message'])) {
+        if (!filter_has_var(INPUT_GET, 'error_description') || !filter_has_var(INPUT_GET, 'hint') || !filter_has_var(INPUT_GET, 'message')) {
             return $message;
         }
 
-        $error_description = sanitize_text_field(wp_unslash($_GET['error_description']));
-        $error_message = sanitize_text_field(wp_unslash($_GET['message']));
-        $hint = sanitize_text_field(wp_unslash($_GET['hint']));
+        // All raw $_GET reads collected here.
+        $error_description_raw = filter_input(INPUT_GET, 'error_description', FILTER_UNSAFE_RAW);
+        $error_message_raw = filter_input(INPUT_GET, 'message', FILTER_UNSAFE_RAW);
+        $hint_raw = filter_input(INPUT_GET, 'hint', FILTER_UNSAFE_RAW);
+
+        // All parameters are sanitized as they may contain untrusted data.
+        $error_description = is_string($error_description_raw) ? sanitize_text_field(wp_unslash($error_description_raw)) : '';
+        $error_message = is_string($error_message_raw) ? sanitize_text_field(wp_unslash($error_message_raw)) : '';
+        $hint = is_string($hint_raw) ? sanitize_text_field(wp_unslash($hint_raw)) : '';
 
         // If the error equals `The user denied the request`, show a translated message
         if ($hint == 'The user denied the request') {
@@ -412,9 +427,17 @@ class Auth {
         $scopes = array_map('sanitize_text_field', explode(" ", get_option('scouting_oidc_scopes')));
 
         // Check if error_description, hint, and message are set in the URL
-        if (isset($_GET['error_description'], $_GET['hint'])) {
-            $error_description = sanitize_text_field(wp_unslash($_GET['error_description']));
-            $hint = sanitize_text_field(wp_unslash($_GET['hint']));
+        if (filter_has_var(INPUT_GET, 'error_description') && filter_has_var(INPUT_GET, 'hint')) {
+
+            // All raw $_GET reads collected here.
+            $error_description_raw = filter_input(INPUT_GET, 'error_description', FILTER_UNSAFE_RAW);
+            $hint_raw = filter_input(INPUT_GET, 'hint', FILTER_UNSAFE_RAW);
+
+            // All parameters are sanitized as they may contain untrusted data.
+            $error_description = is_string($error_description_raw) ? sanitize_text_field(wp_unslash($error_description_raw)) : '';
+            $hint = is_string($hint_raw) ? sanitize_text_field(wp_unslash($hint_raw)) : '';
+
+            // If the error equals `init`, it means there was an error during the initialization of the login URL, so we log it and return a custom URL that indicates an initialization error with the hint as a parameter
             if ($error_description == 'init') {
                 Logger::error(LogComponent::AUTH, "OIDC login URL builder returning init error: {$hint}");
                 return "init_error:" . $hint;

--- a/src/auth/OpenIDConnectClient.php
+++ b/src/auth/OpenIDConnectClient.php
@@ -130,11 +130,11 @@ class OpenIDConnectClient
             ErrorHandler::redirect_to_login_error('init', $hint, 'scopes_not_saved');
         }
 
-        // Generate and store a nonce in the session
-        $nonce = $this->setNonce();
-
         // State essentially acts as a session key for OIDC
         $state = $this->setState($this->generateToken(32));
+
+        // Generate and store a nonce bound to this state so multiple pending logins do not overwrite each other
+        $nonce = $this->setNonceForState($state);
 
         // PKCE: generate and store a code verifier bound to this state, then derive the S256 challenge
         $code_verifier = $this->generateCodeVerifier();
@@ -247,7 +247,7 @@ class OpenIDConnectClient
      */
     public function unsetStatesAndNonce(): void {
         $this->session->scouting_oidc_session_delete('scouting_oidc_states');
-        $this->session->scouting_oidc_session_delete('scouting_oidc_nonce');
+        $this->session->scouting_oidc_session_delete('scouting_oidc_nonces');
         $this->session->scouting_oidc_session_delete('scouting_oidc_code_verifiers');
 
         Logger::debug(LogComponent::OIDC, 'OIDC state, nonce and PKCE verifier session data cleared');
@@ -622,25 +622,40 @@ class OpenIDConnectClient
     }
 
     /**
-     * Generates and stores a cryptographically secure random nonce in the session.
-     * 
+     * Generates and stores a cryptographically secure random nonce keyed by state.
+     *
+     * @param string $state the OIDC state value
      * @return string the nonce
      */
-    private function setNonce(): string {
+    private function setNonceForState(string $state): string {
+        $nonces = $this->session->scouting_oidc_session_get('scouting_oidc_nonces') ?? [];
+        if (!is_array($nonces)) {
+            $nonces = [];
+        }
+
         $nonce = bin2hex($this->generateRandomBytes(16));
-        $this->session->scouting_oidc_session_set('scouting_oidc_nonce', $nonce);
+        $nonces[$state] = $nonce;
+        $this->session->scouting_oidc_session_set('scouting_oidc_nonces', $nonces);
+
         return $nonce;
     }
 
     /**
-     * Get stored nonce from the session
+     * Gets the stored nonce for the given state from the session.
      *
-     * @return string the nonce from the session
+     * @param string $state the OIDC state value
+     * @return string the nonce from the session or an empty string
      */
-    public function getNonce(): string {
-        $nonce = $this->session->scouting_oidc_session_get('scouting_oidc_nonce');
+    public function getNonceForState(string $state): string {
+        $nonces = $this->session->scouting_oidc_session_get('scouting_oidc_nonces');
+        if (is_array($nonces)) {
+            $nonce = $nonces[$state] ?? null;
+            if (is_string($nonce) && $nonce !== '') {
+                return $nonce;
+            }
+        }
 
-        return is_string($nonce) ? $nonce : '';
+        return '';
     }
 
     /**

--- a/src/auth/OpenIDConnectClient.php
+++ b/src/auth/OpenIDConnectClient.php
@@ -319,8 +319,19 @@ class OpenIDConnectClient
         // Convert the certificate chain (x5c) to a public key certificate
         $public_key_certificate = "-----BEGIN CERTIFICATE-----\n" . chunk_split($x5c, 64, "\n") . "-----END CERTIFICATE-----";
 
-        // Check if the signature is valid
+        // Check if the signing certificate can be converted to a public key before verifying the signature
         $publicKey = openssl_pkey_get_public($public_key_certificate);
+        if ($publicKey === false) {
+            $opensslError = openssl_error_string();
+            $logMessage = 'ID token validation failed: unable to extract public key from signing certificate';
+            if ($opensslError !== false) {
+                $logMessage .= ' (' . $opensslError . ')';
+            }
+            Logger::error(LogComponent::OIDC, $logMessage);
+            ErrorHandler::redirect_to_login_error('error', __('The signing certificate used to validate the ID token is invalid or unsupported.', 'scouting-openid-connect'), 'invalid_signing_certificate');
+        }
+
+        // Check if the signature is valid
         $signatureValid = openssl_verify($headerEncoded . '.' . $payloadEncoded, $signature, $publicKey, OPENSSL_ALGO_SHA256);
         if ($signatureValid !== 1) {
             Logger::error(LogComponent::OIDC, 'ID token signature validation failed');

--- a/src/auth/OpenIDConnectClient.php
+++ b/src/auth/OpenIDConnectClient.php
@@ -255,10 +255,15 @@ class OpenIDConnectClient
 
     /**
      * Validates the ID token and returns the payload
-     * 
-     * @return array returns the payload 
+     *
+     * Performs full OIDC validation: structure check, algorithm guard, signature
+     * verification against the JWKS x5c certificate, and standard claim checks
+     * (iss, aud, exp, sub, nonce).
+     *
+     * @param string $stored_nonce The nonce saved before retrieveTokens cleared session state.
+     * @return array returns the validated payload
      */
-    public function validateTokens(): array {
+    public function validateTokens(string $stored_nonce = ''): array {
         Logger::debug(LogComponent::OIDC, 'ID token validation started');
         $this->getWellKnownData();
         $this->getJWKSData();
@@ -275,13 +280,26 @@ class OpenIDConnectClient
             ErrorHandler::redirect_to_login_error('error', __('The JSON Web Key Set (JWKS) is not available.', 'scouting-openid-connect'), 'jwks_is_missing');
         }
 
-        // Split the token into header, payload and signature
-        list($headerEncoded, $payloadEncoded, $signatureEncoded) = explode('.', $this->tokens->id_token);
-        
+        // Validate JWT has exactly 3 segments before splitting
+        $parts = explode('.', $this->tokens->id_token);
+        if (count($parts) !== 3) {
+            Logger::error(LogComponent::OIDC, 'ID token has an invalid structure: expected 3 dot-separated segments, got ' . count($parts));
+            ErrorHandler::redirect_to_login_error('error', __('The ID token has an invalid structure.', 'scouting-openid-connect'), 'malformed_token');
+        }
+
+        [$headerEncoded, $payloadEncoded, $signatureEncoded] = $parts;
+
         // Decode the header, payload and signature
         $header = json_decode($this->base64UrlDecode($headerEncoded), true);
         $payload = json_decode($this->base64UrlDecode($payloadEncoded), true);
         $signature = $this->base64UrlDecode($signatureEncoded);
+
+        // Validate the algorithm header to prevent unexpected algorithm attacks
+        $expected_alg = 'RS256';
+        if (!is_array($header) || ($header['alg'] ?? '') !== $expected_alg) {
+            Logger::error(LogComponent::OIDC, 'ID token uses an unexpected algorithm: ' . ($header['alg'] ?? 'none'));
+            ErrorHandler::redirect_to_login_error('error', __('The ID token uses an unexpected signing algorithm.', 'scouting-openid-connect'), 'invalid_alg');
+        }
 
         // Loop through the keys in the JSON Web Key Set (JWKS) to find the certificate chain (x5c) for the key ID (kid) specified in the header
         $x5c = null;
@@ -306,12 +324,51 @@ class OpenIDConnectClient
         $signatureValid = openssl_verify($headerEncoded . '.' . $payloadEncoded, $signature, $publicKey, OPENSSL_ALGO_SHA256);
         if ($signatureValid !== 1) {
             Logger::error(LogComponent::OIDC, 'ID token signature validation failed');
-            ErrorHandler::redirect_to_login_error('error', __('The signature in the ID token is not valid.', 'scouting-openid-connect'), 'jwks_is_missing');
+            ErrorHandler::redirect_to_login_error('error', __('The signature in the ID token is not valid.', 'scouting-openid-connect'), 'invalid_signature');
         }
-        else {
-            Logger::debug(LogComponent::OIDC, 'ID token validation succeeded');
-            return $payload;
+
+        // Validate standard OIDC claims after signature is confirmed
+        if (!is_array($payload)) {
+            Logger::error(LogComponent::OIDC, 'ID token payload could not be decoded');
+            ErrorHandler::redirect_to_login_error('error', __('The ID token payload could not be decoded.', 'scouting-openid-connect'), 'malformed_token');
         }
+
+        // iss: must match the configured issuer
+        if (($payload['iss'] ?? '') !== $this->issuer) {
+            Logger::error(LogComponent::OIDC, 'ID token issuer mismatch: expected ' . $this->issuer . ', got ' . ($payload['iss'] ?? '(missing)'));
+            ErrorHandler::redirect_to_login_error('error', __('The ID token was issued by an unexpected issuer.', 'scouting-openid-connect'), 'invalid_iss');
+        }
+
+        // aud: must contain the configured client ID
+        $audience = (array) ($payload['aud'] ?? []);
+        if (!in_array($this->clientID, $audience, true)) {
+            Logger::error(LogComponent::OIDC, 'ID token audience does not include the configured client ID');
+            ErrorHandler::redirect_to_login_error('error', __('The ID token was not issued for this client.', 'scouting-openid-connect'), 'invalid_aud');
+        }
+
+        // exp: token must not be expired
+        if (($payload['exp'] ?? 0) < time()) {
+            Logger::error(LogComponent::OIDC, 'ID token has expired (exp=' . ($payload['exp'] ?? 'missing') . ')');
+            ErrorHandler::redirect_to_login_error('error', __('The ID token has expired.', 'scouting-openid-connect'), 'token_expired');
+        }
+
+        // sub: subject must be present
+        if (empty($payload['sub'])) {
+            Logger::error(LogComponent::OIDC, 'ID token is missing the sub claim');
+            ErrorHandler::redirect_to_login_error('error', __('The ID token is missing the required sub claim.', 'scouting-openid-connect'), 'missing_sub');
+        }
+
+        // Validate the nonce claim against the value sent in the auth request
+        if (!empty($stored_nonce)) {
+            $token_nonce = $payload['nonce'] ?? '';
+            if ($token_nonce === '' || !hash_equals($stored_nonce, $token_nonce)) {
+                Logger::error(LogComponent::OIDC, 'ID token nonce mismatch: the nonce in the token does not match the session nonce');
+                ErrorHandler::redirect_to_login_error('error', __('The ID token nonce is invalid.', 'scouting-openid-connect'), 'nonce_mismatch');
+            }
+        }
+
+        Logger::debug(LogComponent::OIDC, 'ID token validation succeeded');
+        return $payload;
     }
 
     /**
@@ -354,8 +411,9 @@ class OpenIDConnectClient
      * @return void
      */
     public function getWellKnownData(): void {
-        // Define a transient key for caching the well-known data
-        $transient_key = 'scouting_oidc_well_known_data';
+        // Define a transient key for caching the well-known data, scoped to the issuer
+        // so that changing the issuer in settings does not serve stale cached data.
+        $transient_key = 'scouting_oidc_wk_' . md5($this->issuer);
 
         // Check if the well-known data already exists in the cache (transient)
         $well_known_data = get_transient($transient_key);
@@ -400,8 +458,9 @@ class OpenIDConnectClient
      * @return void
      */
     public function getJWKSData(): void {
-        // Define a transient key for caching the JWKS data
-        $transient_key = 'scouting_oidc_jwks_data';
+        // Define a transient key for caching the JWKS data, scoped to the issuer
+        // so that changing the issuer in settings does not serve stale cached keys.
+        $transient_key = 'scouting_oidc_jwks_' . md5($this->issuer);
     
         // Check if the JWKS data already exists in the cache (transient)
         $jwks_data = get_transient($transient_key);
@@ -480,26 +539,13 @@ class OpenIDConnectClient
     }
 
     /**
-     * Generates a random token
+     * Generates a cryptographically secure random token
      *
-     * @param int $length the length of the token
+     * @param int $length the length of the token (characters)
      * @return string the token
      */
     private function generateToken(int $length): string {
-        //set up random characters
-        $chars='1234567890qwertyuiopasdfghjklzxcvbnmQWERTYUIOPASDFGHJKLZXCVBNM';
-        // Get the length of the random characters
-        $char_len = strlen($chars)-1;
-        //store output
-        $output = '';
-        //iterate over $chars
-        while (strlen($output) < $length) {
-            /* get random characters and append to output till the length of the output 
-             is greater than the length provided */
-            $output .= $chars[wp_rand(0, $char_len)];
-        }
-        //return the result
-        return $output;
+        return substr(bin2hex(random_bytes((int) ceil($length / 2))), 0, $length);
     }
 
     /**
@@ -532,12 +578,12 @@ class OpenIDConnectClient
     }
 
     /**
-     * Generates and stores a nonce in the session
+     * Generates and stores a cryptographically secure random nonce in the session.
      * 
      * @return string the nonce
      */
     private function setNonce(): string {
-        $nonce = wp_create_nonce('scouting_oidc_nonce');
+        $nonce = bin2hex(random_bytes(16));
         $this->session->scouting_oidc_session_set('scouting_oidc_nonce', $nonce);
         return $nonce;
     }

--- a/src/auth/OpenIDConnectClient.php
+++ b/src/auth/OpenIDConnectClient.php
@@ -352,6 +352,12 @@ class OpenIDConnectClient
             ErrorHandler::redirect_to_login_error('error', __('The ID token has expired.', 'scouting-openid-connect'), 'token_expired');
         }
 
+        // iat: reject tokens that appear to be issued too far in the future (allow small clock skew)
+        if (($payload['iat'] ?? 0) > (time() + 60)) {
+            Logger::error(LogComponent::OIDC, 'ID token has an invalid issued-at time in the future (iat=' . ($payload['iat'] ?? 'missing') . ')');
+            ErrorHandler::redirect_to_login_error('error', __('The ID token has an invalid issued-at timestamp.', 'scouting-openid-connect'), 'invalid_iat');
+        }
+
         // sub: subject must be present
         if (empty($payload['sub'])) {
             Logger::error(LogComponent::OIDC, 'ID token is missing the sub claim');

--- a/src/auth/OpenIDConnectClient.php
+++ b/src/auth/OpenIDConnectClient.php
@@ -554,9 +554,11 @@ class OpenIDConnectClient
         try {
             return random_bytes($length);
         } catch (\Exception $e) {
-            wp_die(
-                esc_html__('Authentication is temporarily unavailable. Please try again later.', 'scouting-oidc'),
-                esc_html__('Authentication Error', 'scouting-oidc')
+            Logger::error(LogComponent::OIDC, 'Failed to generate random bytes.');
+            ErrorHandler::redirect_to_login_error(
+                'init',
+                __('Authentication is temporarily unavailable. Please try again later.', 'scouting-openid-connect'),
+                'random_bytes_failed'
             );
         }
     }
@@ -606,7 +608,7 @@ class OpenIDConnectClient
      * @return string the nonce
      */
     private function setNonce(): string {
-        $nonce = bin2hex(random_bytes(16));
+        $nonce = bin2hex($this->generateRandomBytes(16));
         $this->session->scouting_oidc_session_set('scouting_oidc_nonce', $nonce);
         return $nonce;
     }

--- a/src/auth/OpenIDConnectClient.php
+++ b/src/auth/OpenIDConnectClient.php
@@ -376,12 +376,20 @@ class OpenIDConnectClient
         }
 
         // Validate the nonce claim against the value sent in the auth request
-        if (!empty($stored_nonce)) {
-            $token_nonce = $payload['nonce'] ?? '';
-            if ($token_nonce === '' || !hash_equals($stored_nonce, $token_nonce)) {
-                Logger::error(LogComponent::OIDC, 'ID token nonce mismatch: the nonce in the token does not match the session nonce');
-                ErrorHandler::redirect_to_login_error('error', __('The ID token nonce is invalid.', 'scouting-openid-connect'), 'nonce_mismatch');
-            }
+        if (empty($stored_nonce)) {
+            Logger::error(LogComponent::OIDC, 'ID token nonce validation failed: no stored nonce available in session state');
+            ErrorHandler::redirect_to_login_error('error', __('The login session is invalid or has expired.', 'scouting-openid-connect'), 'missing_nonce');
+        }
+
+        $token_nonce = $payload['nonce'] ?? '';
+        if ($token_nonce === '') {
+            Logger::error(LogComponent::OIDC, 'ID token is missing the nonce claim');
+            ErrorHandler::redirect_to_login_error('error', __('The ID token is missing the required nonce claim.', 'scouting-openid-connect'), 'missing_token_nonce');
+        }
+
+        if (!hash_equals($stored_nonce, $token_nonce)) {
+            Logger::error(LogComponent::OIDC, 'ID token nonce mismatch: the nonce in the token does not match the session nonce');
+            ErrorHandler::redirect_to_login_error('error', __('The ID token nonce is invalid.', 'scouting-openid-connect'), 'nonce_mismatch');
         }
 
         Logger::debug(LogComponent::OIDC, 'ID token validation succeeded');

--- a/src/auth/OpenIDConnectClient.php
+++ b/src/auth/OpenIDConnectClient.php
@@ -545,13 +545,30 @@ class OpenIDConnectClient
     }
 
     /**
+     * Generates cryptographically secure random bytes and converts failures into a controlled auth error.
+     *
+     * @param int $length the number of bytes to generate
+     * @return string the random bytes
+     */
+    private function generateRandomBytes(int $length): string {
+        try {
+            return random_bytes($length);
+        } catch (\Exception $e) {
+            wp_die(
+                esc_html__('Authentication is temporarily unavailable. Please try again later.', 'scouting-oidc'),
+                esc_html__('Authentication Error', 'scouting-oidc')
+            );
+        }
+    }
+
+    /**
      * Generates a cryptographically secure random token
      *
      * @param int $length the length of the token (characters)
      * @return string the token
      */
     private function generateToken(int $length): string {
-        return substr(bin2hex(random_bytes((int) ceil($length / 2))), 0, $length);
+        return substr(bin2hex($this->generateRandomBytes((int) ceil($length / 2))), 0, $length);
     }
 
     /**
@@ -567,7 +584,7 @@ class OpenIDConnectClient
 
         $verifier = '';
         while (strlen($verifier) < $length) {
-            $verifier .= $this->base64UrlEncode(random_bytes(32));
+            $verifier .= $this->base64UrlEncode($this->generateRandomBytes(32));
         }
 
         return substr($verifier, 0, $length);

--- a/src/logging/Help.php
+++ b/src/logging/Help.php
@@ -38,7 +38,13 @@ class LoggingHelp
             'title' => __('Export and Retention', 'scouting-openid-connect'),
             'content' =>
                 '<p>' . esc_html__('Use the Download .log button to export the currently filtered logs.', 'scouting-openid-connect') . '</p>' .
-                '<p>' . esc_html__('A daily cleanup task removes log entries older than 30 days.', 'scouting-openid-connect') . '</p>'
+                '<p>' . esc_html(
+                    sprintf(
+                        /* translators: %d: Number of days log entries are kept before cleanup. */
+                        __('A daily cleanup task removes log entries older than %d day(s).', 'scouting-openid-connect'),
+                        CronJobs::scouting_oidc_get_log_retention_days()
+                    )
+                ) . '</p>'
         ]);
 
         $screen->add_help_tab([

--- a/src/settings/General.php
+++ b/src/settings/General.php
@@ -137,6 +137,15 @@ class Settings_General
             'scouting-openid-connect-settings',                                // Page slug
             'scouting_oidc_general_settings'                                   // Section ID where the field should be added
         );
+
+        // Add a settings number field
+        add_settings_field(
+            'scouting_oidc_log_retention_days',                                      // Field ID
+            __('Log retention (days)', 'scouting-openid-connect'),                   // Field label
+            [$this, 'scouting_oidc_settings_general_log_retention_days_callback'],   // Callback to render field
+            'scouting-openid-connect-settings',                                       // Page slug
+            'scouting_oidc_general_settings'                                          // Section ID where the field should be added
+        );
     
         // Register settings
         register_setting(
@@ -248,6 +257,15 @@ class Settings_General
             ]
         );
 
+        // Register settings
+        register_setting(
+            'scouting_oidc_settings_group',                                                    // Settings group name
+            'scouting_oidc_log_retention_days',                                                // Option name
+            [
+                'sanitize_callback' => [$this, 'scouting_oidc_sanitize_log_retention_days_option'] // Sanitize retention days as bounded integer
+            ]
+        );
+
         // Log settings changes for options that belong to this plugin
         add_action('updated_option', [$this, 'handle_option_update'], 10, 3);
     }
@@ -332,6 +350,30 @@ class Settings_General
      */
     public function scouting_oidc_sanitize_boolean_option(mixed $input): int {
         return $input ? 1 : 0;
+    }
+
+    /**
+     * Sanitize the log retention option.
+     *
+     * @param mixed $input
+     * @return int
+     */
+    public function scouting_oidc_sanitize_log_retention_days_option(mixed $input): int {
+        if (!is_numeric($input)) {
+            return 30;
+        }
+
+        $retention_days = (int) $input;
+
+        if ($retention_days < 1) {
+            return 1;
+        }
+
+        if ($retention_days > 3650) {
+            return 3650;
+        }
+
+        return $retention_days;
     }
 
     /**
@@ -561,6 +603,21 @@ class Settings_General
         echo '<span style="padding: 5.675px 3px 5.675px 0px;">' . esc_html($base_domain) . '</span>';
         echo '<input type="text" id="scouting_oidc_custom_redirect" name="scouting_oidc_custom_redirect" size="50" value="' . esc_attr($slug) . '" placeholder="' . esc_attr__("custom-page", "scouting-openid-connect") . '"/>';
         echo '<p class="description">' . esc_html__("Enter the slug to append to the base URL where users should be redirected after login.", "scouting-openid-connect") . '</p>';
+    }
+
+    /**
+     * Callback to render log retention days number field.
+     *
+     * @return void
+     */
+    public function scouting_oidc_settings_general_log_retention_days_callback(): void {
+        $value = (int) get_option('scouting_oidc_log_retention_days', 30);
+        if ($value < 1) {
+            $value = 1;
+        }
+
+        echo '<input type="number" id="scouting_oidc_log_retention_days" name="scouting_oidc_log_retention_days" min="1" max="3650" step="1" value="' . esc_attr((string) $value) . '" style="width: 95px;"/>';
+        echo '<p class="description">' . esc_html__('Logs may contain personal data such as user IDs and SOL IDs. Set how many days logs are retained before daily cleanup removes older entries.', 'scouting-openid-connect') . '</p>';
     }
 
     /**

--- a/src/settings/Oidc.php
+++ b/src/settings/Oidc.php
@@ -105,9 +105,8 @@ class Settings_Oidc
         $toggle_id = 'scouting_oidc_client_secret_toggle';
         $show_text = __('Show', 'scouting-openid-connect');
         $hide_text = __('Hide', 'scouting-openid-connect');
-        $required_attr = $has_secret ? '' : ' required';
 
-        echo '<input type="password" id="' . esc_attr($input_id) . '" name="scouting_oidc_client_secret" placeholder="' . esc_attr__("Enter new client secret", "scouting-openid-connect") . '" value="" size="55"' . $required_attr . ' />';
+        echo '<input type="password" id="' . esc_attr($input_id) . '" name="scouting_oidc_client_secret" placeholder="' . esc_attr__('Enter new client secret', 'scouting-openid-connect') . '" value="" size="55"' . ( $has_secret ? '' : ' required' ) . ' />';
         echo ' <button type="button" class="button" id="' . esc_attr($toggle_id) . '" data-show-text="' . esc_attr($show_text) . '" data-hide-text="' . esc_attr($hide_text) . '" disabled>' . esc_html($show_text) . '</button>';
         if ($has_secret) {
             echo '<p class="description">' . esc_html__("A client secret is already stored. Leave this field empty to keep the current secret. For security reasons, the stored value cannot be shown here.", "scouting-openid-connect") . '</p>';

--- a/src/settings/Page.php
+++ b/src/settings/Page.php
@@ -112,6 +112,7 @@ class Settings
         add_option('scouting_oidc_login_redirect', 'frontpage');
         add_option('scouting_oidc_custom_redirect', '');
         add_option('scouting_oidc_debug_logging_enabled', false);
+        add_option('scouting_oidc_log_retention_days', 30);
     }
 }
 ?>

--- a/src/settings/Page.php
+++ b/src/settings/Page.php
@@ -95,23 +95,23 @@ class Settings
      */
     public function scouting_oidc_settings_install(): void {
         // Set default options for OIDC
-        update_option('scouting_oidc_client_id', '');
-        update_option('scouting_oidc_client_secret', '');
-        update_option('scouting_oidc_scopes', 'openid membership profile email address phone');
+        add_option('scouting_oidc_client_id', '');
+        add_option('scouting_oidc_client_secret', '');
+        add_option('scouting_oidc_scopes', 'openid membership profile email address phone');
 
         // Set default options for general settings
-        update_option('scouting_oidc_user_display_name', 'fullname');
-        update_option('scouting_oidc_user_birthdate', false);
-        update_option('scouting_oidc_user_gender', false);
-        update_option('scouting_oidc_user_phone', false);
-        update_option('scouting_oidc_user_address', false);
-        update_option('scouting_oidc_user_woocommerce_sync', false);
-        update_option('scouting_oidc_user_auto_create', true);
-        update_option('scouting_oidc_user_duplicate_email', 'plus_addressing');
-        update_option('scouting_oidc_user_redirect', true);
-        update_option('scouting_oidc_login_redirect', 'frontpage');
-        update_option('scouting_oidc_custom_redirect', '');
-        update_option('scouting_oidc_debug_logging_enabled', false);
+        add_option('scouting_oidc_user_display_name', 'fullname');
+        add_option('scouting_oidc_user_birthdate', false);
+        add_option('scouting_oidc_user_gender', false);
+        add_option('scouting_oidc_user_phone', false);
+        add_option('scouting_oidc_user_address', false);
+        add_option('scouting_oidc_user_woocommerce_sync', false);
+        add_option('scouting_oidc_user_auto_create', true);
+        add_option('scouting_oidc_user_duplicate_email', 'plus_addressing');
+        add_option('scouting_oidc_user_redirect', true);
+        add_option('scouting_oidc_login_redirect', 'frontpage');
+        add_option('scouting_oidc_custom_redirect', '');
+        add_option('scouting_oidc_debug_logging_enabled', false);
     }
 }
 ?>

--- a/src/user/User.php
+++ b/src/user/User.php
@@ -111,15 +111,15 @@ class User {
         $this->emailVerified = rest_sanitize_boolean($user_json_decoded['email_verified'] ?? false);
 
         // Profile scope data
-        $this->fullName = $user_json_decoded['name'] ?? "";
-        $this->firstName = $user_json_decoded['given_name'] ?? "";
-        $this->infix = $user_json_decoded['infix'] ?? "";
-        $this->familyName = $user_json_decoded['family_name'] ?? "";
-        $this->gender = $user_json_decoded['gender'] ?? "unknown";
-        $this->birthdate = $user_json_decoded['birthdate'] ?? "";
+        $this->fullName   = sanitize_text_field($user_json_decoded['name'] ?? '');
+        $this->firstName  = sanitize_text_field($user_json_decoded['given_name'] ?? '');
+        $this->infix      = sanitize_text_field($user_json_decoded['infix'] ?? '');
+        $this->familyName = sanitize_text_field($user_json_decoded['family_name'] ?? '');
+        $this->gender     = sanitize_text_field($user_json_decoded['gender'] ?? 'unknown');
+        $this->birthdate  = sanitize_text_field($user_json_decoded['birthdate'] ?? '');
 
         // Profile scope - Language preference
-        $locale = $user_json_decoded['locale'] ?? '';
+        $locale = sanitize_text_field($user_json_decoded['locale'] ?? '');
         $normalized_locale = strtolower(str_replace('-', '_', $locale));
         if ($normalized_locale === 'nl' || strpos($normalized_locale, 'nl_') === 0) {
             $this->language = 'nl_NL';
@@ -131,26 +131,30 @@ class User {
 
         // Optional scopes data
         // Phone scope data
-        $this->phoneNumber = $user_json_decoded['phone_number'] ?? "";
+        $this->phoneNumber = sanitize_text_field($user_json_decoded['phone_number'] ?? '');
         $this->phoneNumberVerified = rest_sanitize_boolean($user_json_decoded['phone_number_verified'] ?? false);
 
         // Address scope data
         $address = is_array($user_json_decoded['address'] ?? null) ? $user_json_decoded['address'] : [];
-        $this->street = $address['street'] ?? "";
-        $this->houseNumber = $address['house_number'] ?? "";
-        $this->postalCode = $address['postal_code'] ?? "";
-        $this->locality = $address['locality'] ?? "";
-        $this->countryCode = $address['country_code'] ?? "";
+        $this->street      = sanitize_text_field($address['street'] ?? '');
+        $this->houseNumber = sanitize_text_field($address['house_number'] ?? '');
+        $this->postalCode  = sanitize_text_field($address['postal_code'] ?? '');
+        $this->locality    = sanitize_text_field($address['locality'] ?? '');
+        $this->countryCode = sanitize_text_field($address['country_code'] ?? '');
 
         // Validate SOL ID is present
         if (empty($this->sol_id)) {
-            Logger::error(LogComponent::USER, "Construction of User object failed: SOL ID is missing in the user data received from the OpenID Connect server. User data: " . json_encode($user_json_decoded));
+            // Log only which claims are present/absent — never dump personal claim values
+            $present_claims = implode(', ', array_keys($user_json_decoded));
+            Logger::error(LogComponent::USER, "Construction of User object failed: SOL ID is missing in the user data received from the OpenID Connect server. Present claims: " . $present_claims);
             ErrorHandler::redirect_to_login_error('error', __('SOL ID is missing, make sure the "membership" scope is enabled.', 'scouting-openid-connect'), 'sol_id_is_missing');
         }
 
         // Validate email is present
         if (empty($this->email)) {
-            Logger::error(LogComponent::USER, "Construction of User object failed: Email is missing in the user data received from the OpenID Connect server. User data: " . json_encode($user_json_decoded), null, $this->sol_id);
+            // Log only which claims are present/absent — never dump personal claim values
+            $present_claims = implode(', ', array_keys($user_json_decoded));
+            Logger::error(LogComponent::USER, "Construction of User object failed: Email is missing in the user data received from the OpenID Connect server. Present claims: " . $present_claims, null, $this->sol_id);
             ErrorHandler::redirect_to_login_error('error', __('Email is missing, make sure the "email" scope is enabled.', 'scouting-openid-connect'), 'email_is_missing');
         }
     }

--- a/src/utilities/CronJobs.php
+++ b/src/utilities/CronJobs.php
@@ -13,24 +13,24 @@ class CronJobs {
     public const CLEANUP_CRON_HOOK = 'scouting_oidc_logs_cleanup_daily';
 
     /**
-        * Default number of days to retain logs.
+     * Default number of days to retain logs.
      */
-        private const DEFAULT_LOG_RETENTION_DAYS = 30;
+    private const DEFAULT_LOG_RETENTION_DAYS = 30;
 
-        /**
-        * Minimum allowed number of days to retain logs.
-        */
-        private const MIN_LOG_RETENTION_DAYS = 1;
+    /**
+     * Minimum allowed number of days to retain logs.
+     */
+    private const MIN_LOG_RETENTION_DAYS = 1;
 
-        /**
-        * Maximum allowed number of days to retain logs.
-        */
-        private const MAX_LOG_RETENTION_DAYS = 3650;
+    /**
+     * Maximum allowed number of days to retain logs.
+     */
+    private const MAX_LOG_RETENTION_DAYS = 3650;
 
-        /**
-        * Option key for log retention days.
-        */
-        private const LOG_RETENTION_OPTION = 'scouting_oidc_log_retention_days';
+    /**
+     * Option key for log retention days.
+     */
+    private const LOG_RETENTION_OPTION = 'scouting_oidc_log_retention_days';
 
     /**
      * Schedule cleanup jobs when plugin is activated.

--- a/src/utilities/CronJobs.php
+++ b/src/utilities/CronJobs.php
@@ -13,9 +13,24 @@ class CronJobs {
     public const CLEANUP_CRON_HOOK = 'scouting_oidc_logs_cleanup_daily';
 
     /**
-     * Number of days to retain logs.
+        * Default number of days to retain logs.
      */
-    private const LOG_RETENTION_DAYS = 30;
+        private const DEFAULT_LOG_RETENTION_DAYS = 30;
+
+        /**
+        * Minimum allowed number of days to retain logs.
+        */
+        private const MIN_LOG_RETENTION_DAYS = 1;
+
+        /**
+        * Maximum allowed number of days to retain logs.
+        */
+        private const MAX_LOG_RETENTION_DAYS = 3650;
+
+        /**
+        * Option key for log retention days.
+        */
+        private const LOG_RETENTION_OPTION = 'scouting_oidc_log_retention_days';
 
     /**
      * Schedule cleanup jobs when plugin is activated.
@@ -77,6 +92,7 @@ class CronJobs {
         global $wpdb;
 
         $logs_table = $wpdb->prefix . 'scouting_oidc_logs';
+        $retention_days = self::scouting_oidc_get_log_retention_days();
 
         // Compare against UTC so the retention window matches the UTC timestamp stored in the table.
         // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
@@ -84,7 +100,7 @@ class CronJobs {
             $wpdb->prepare(
                 'DELETE FROM %i WHERE created_at < (UTC_TIMESTAMP(3) - INTERVAL %d DAY)',
                 $logs_table,
-                self::LOG_RETENTION_DAYS
+                $retention_days
             )
         );
 
@@ -93,7 +109,32 @@ class CronJobs {
             return;
         }
 
-        Logger::info(LogComponent::CRONJOB, 'Cron cleanup removed ' . (string) $result . ' old log row(s).');
+        Logger::info(LogComponent::CRONJOB, 'Cron cleanup removed ' . (string) $result . ' old log row(s) older than ' . (string) $retention_days . ' day(s).');
+    }
+
+    /**
+     * Get the configured log retention period in days.
+     *
+     * @return int
+     */
+    public static function scouting_oidc_get_log_retention_days(): int {
+        $configured_retention_days = get_option(self::LOG_RETENTION_OPTION, self::DEFAULT_LOG_RETENTION_DAYS);
+
+        if (!is_numeric($configured_retention_days)) {
+            return self::DEFAULT_LOG_RETENTION_DAYS;
+        }
+
+        $retention_days = (int) $configured_retention_days;
+
+        if ($retention_days < self::MIN_LOG_RETENTION_DAYS) {
+            return self::MIN_LOG_RETENTION_DAYS;
+        }
+
+        if ($retention_days > self::MAX_LOG_RETENTION_DAYS) {
+            return self::MAX_LOG_RETENTION_DAYS;
+        }
+
+        return $retention_days;
     }
 
     /**

--- a/uninstall.php
+++ b/uninstall.php
@@ -27,15 +27,27 @@ foreach ($scouting_oidc_options as $scouting_oidc_option) {
     delete_option($scouting_oidc_option);
 }
 
-// Delete transients
-$scouting_oidc_transients = array(
-    'scouting_oidc_well_known_data',
-    'scouting_oidc_jwks_data',
+// Delete issuer-scoped transient rows (e.g. scouting_oidc_wk_<hash>, scouting_oidc_jwks_<hash>)
+$scouting_oidc_transient_prefixes = array(
+    'scouting_oidc_wk_',
+    'scouting_oidc_jwks_',
 );
 
-foreach ($scouting_oidc_transients as $scouting_oidc_transient) {
-    delete_transient($scouting_oidc_transient);
+// Build LIKE patterns for both transient and transient_timeout rows for each prefix to delete all relevant transients in a single query for scalability.
+$scouting_oidc_transient_like_patterns = array();
+foreach ($scouting_oidc_transient_prefixes as $scouting_oidc_transient_prefix) {
+    $scouting_oidc_escaped_prefix = $wpdb->esc_like($scouting_oidc_transient_prefix);
+    $scouting_oidc_transient_like_patterns[] = '_transient_' . $scouting_oidc_escaped_prefix . '%';
+    $scouting_oidc_transient_like_patterns[] = '_transient_timeout_' . $scouting_oidc_escaped_prefix . '%';
 }
+
+// Prepare the WHERE clause with placeholders for each LIKE pattern based on the number of patterns to delete and construct the full SQL query to delete all matching transients in one go for better performance.
+$scouting_oidc_transient_where_clause = implode(' OR ', array_fill(0, count($scouting_oidc_transient_like_patterns), 'option_name LIKE %s'));
+$scouting_oidc_delete_transients_sql = "DELETE FROM {$wpdb->options} WHERE $scouting_oidc_transient_where_clause";
+
+// Delete all matching transient and timeout rows in one query.
+// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+$wpdb->query($wpdb->prepare($scouting_oidc_delete_transients_sql, $scouting_oidc_transient_like_patterns));
 
 // Delete user meta
 $scouting_oidc_metas = array(
@@ -51,6 +63,7 @@ $scouting_oidc_metas = array(
     'scouting_oidc_country_code',
 );
 
+// Prepare placeholders for the IN clause based on the number of meta keys to delete
 $scouting_oidc_metas_placeholders = implode(', ', array_fill(0, count($scouting_oidc_metas), '%s'));
 $scouting_oidc_delete_usermeta_sql = "DELETE FROM {$wpdb->usermeta} WHERE meta_key IN ($scouting_oidc_metas_placeholders)";
 $scouting_oidc_delete_usermeta_args = array_merge(array($scouting_oidc_delete_usermeta_sql), $scouting_oidc_metas);

--- a/uninstall.php
+++ b/uninstall.php
@@ -2,6 +2,8 @@
 // Exit if uninstall constant is not defined
 if (!defined('WP_UNINSTALL_PLUGIN')) exit;
 
+global $wpdb;
+
 // Delete options
 $scouting_oidc_options = array(
     'scouting_oidc_client_id',
@@ -48,21 +50,18 @@ $scouting_oidc_metas = array(
     'scouting_oidc_locality',
     'scouting_oidc_country_code',
 );
-$scouting_oidc_users = get_users();
 
-foreach ($scouting_oidc_users as $scouting_oidc_user) {
-    foreach ($scouting_oidc_metas as $scouting_oidc_meta) {
-        delete_user_meta($scouting_oidc_user->ID, $scouting_oidc_meta);
-    }
-}
+$scouting_oidc_metas_placeholders = implode(', ', array_fill(0, count($scouting_oidc_metas), '%s'));
+$scouting_oidc_delete_usermeta_sql = "DELETE FROM {$wpdb->usermeta} WHERE meta_key IN ($scouting_oidc_metas_placeholders)";
+$scouting_oidc_delete_usermeta_args = array_merge(array($scouting_oidc_delete_usermeta_sql), $scouting_oidc_metas);
 
-// Delete logs table
-global $wpdb;
-
-// Get the full table name with prefix
-$scouting_oidc_logs_table = $wpdb->prefix . 'scouting_oidc_logs';
+// Delete all matching plugin user meta in one query for scalability.
+// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
+$wpdb->query($wpdb->prepare($scouting_oidc_delete_usermeta_sql, $scouting_oidc_metas));
 
 // Drop the logs table if it exists
+$scouting_oidc_logs_table = $wpdb->prefix . 'scouting_oidc_logs';
+
 // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.SchemaChange, WordPress.DB.DirectDatabaseQuery.NoCaching
 $wpdb->query($wpdb->prepare('DROP TABLE IF EXISTS %i', $scouting_oidc_logs_table));
 ?>

--- a/uninstall.php
+++ b/uninstall.php
@@ -21,6 +21,7 @@ $scouting_oidc_options = array(
     'scouting_oidc_login_redirect',
     'scouting_oidc_custom_redirect',
     'scouting_oidc_debug_logging_enabled',
+    'scouting_oidc_log_retention_days',
     'scouting_oidc_logs_schema_version',
 );
 
@@ -47,7 +48,7 @@ $scouting_oidc_transient_where_clause = implode(' OR ', array_fill(0, count($sco
 $scouting_oidc_delete_transients_sql = "DELETE FROM {$wpdb->options} WHERE $scouting_oidc_transient_where_clause";
 
 // Delete all matching transient and timeout rows in one query.
-// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
 $wpdb->query($wpdb->prepare($scouting_oidc_delete_transients_sql, $scouting_oidc_transient_like_patterns));
 
 // Delete user meta

--- a/uninstall.php
+++ b/uninstall.php
@@ -16,6 +16,7 @@ $scouting_oidc_options = array(
     'scouting_oidc_user_address',
     'scouting_oidc_user_woocommerce_sync',
     'scouting_oidc_user_auto_create',
+    'scouting_oidc_user_duplicate_email',
     'scouting_oidc_user_redirect',
     'scouting_oidc_login_redirect',
     'scouting_oidc_custom_redirect',

--- a/uninstall.php
+++ b/uninstall.php
@@ -68,7 +68,6 @@ $scouting_oidc_metas = array(
 // Prepare placeholders for the IN clause based on the number of meta keys to delete
 $scouting_oidc_metas_placeholders = implode(', ', array_fill(0, count($scouting_oidc_metas), '%s'));
 $scouting_oidc_delete_usermeta_sql = "DELETE FROM {$wpdb->usermeta} WHERE meta_key IN ($scouting_oidc_metas_placeholders)";
-$scouting_oidc_delete_usermeta_args = array_merge(array($scouting_oidc_delete_usermeta_sql), $scouting_oidc_metas);
 
 // Delete all matching plugin user meta in one query for scalability.
 // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared


### PR DESCRIPTION
This pull request introduces several important security and configuration improvements to the OpenID Connect authentication flow and logging system. The most significant changes include stricter and more explicit OIDC token validation, enhanced security for nonce and token generation, and the addition of a configurable log retention period in both the UI and backend. The code now consistently sanitizes and validates all input parameters from user requests, improving overall robustness.

**OpenID Connect Security and Validation Enhancements:**

* Added comprehensive validation of the ID token in `validateTokens`, including checks for JWT structure, signing algorithm enforcement, signature verification, issuer/audience/expiration/issued-at/subject/nonce claims, and improved error handling/logging. The nonce is now explicitly passed and checked to prevent replay attacks. [[1]](diffhunk://#diff-555de8616a6b6a787bcb92ce84c817229364d30567497667c6f36a896fa28978L259-R266) [[2]](diffhunk://#diff-555de8616a6b6a787bcb92ce84c817229364d30567497667c6f36a896fa28978L278-R303) [[3]](diffhunk://#diff-555de8616a6b6a787bcb92ce84c817229364d30567497667c6f36a896fa28978L309-L315)
* Improved nonce and token generation to use cryptographically secure random bytes instead of weaker or WordPress-specific methods. [[1]](diffhunk://#diff-555de8616a6b6a787bcb92ce84c817229364d30567497667c6f36a896fa28978L483-R554) [[2]](diffhunk://#diff-555de8616a6b6a787bcb92ce84c817229364d30567497667c6f36a896fa28978L535-R592)
* All raw `$_GET` parameter access is now centralized and sanitized using `filter_input` and `sanitize_text_field`, reducing the risk of unsanitized input and making the code easier to audit. [[1]](diffhunk://#diff-85b8ac48e5f072540d4194b1db409bfb44fa5675fd6379bbd3473f8803d5b908L161-R192) [[2]](diffhunk://#diff-85b8ac48e5f072540d4194b1db409bfb44fa5675fd6379bbd3473f8803d5b908L198-R213) [[3]](diffhunk://#diff-85b8ac48e5f072540d4194b1db409bfb44fa5675fd6379bbd3473f8803d5b908L243-R262) [[4]](diffhunk://#diff-85b8ac48e5f072540d4194b1db409bfb44fa5675fd6379bbd3473f8803d5b908L422-R440)

**Logging and Configuration Improvements:**

* Added a configurable log retention period (in days) to the plugin settings, including UI field, sanitization, and registration. The log cleanup task and help documentation now reference this configurable value instead of a fixed 30 days. [[1]](diffhunk://#diff-b700b767f47a512885a2fb5a6ca55828e3b7f1e700dd5f804367627e22705df3R141-R149) [[2]](diffhunk://#diff-b700b767f47a512885a2fb5a6ca55828e3b7f1e700dd5f804367627e22705df3R260-R268) [[3]](diffhunk://#diff-b700b767f47a512885a2fb5a6ca55828e3b7f1e700dd5f804367627e22705df3R355-R378) [[4]](diffhunk://#diff-06725eae36f67c9bc08cac7091237e4224108374c82ea9f512859ce2f32c94e9L136-R136) [[5]](diffhunk://#diff-1c6825b4c06d62e0a5f813398a750982640f8de17cd5caee52d456dca0332d30L41-R47)

**Caching Improvements:**

* Scoped the caching keys for well-known OpenID configuration and JWKS data to the issuer, preventing stale cache use when the issuer changes. [[1]](diffhunk://#diff-555de8616a6b6a787bcb92ce84c817229364d30567497667c6f36a896fa28978L357-R422) [[2]](diffhunk://#diff-555de8616a6b6a787bcb92ce84c817229364d30567497667c6f36a896fa28978L403-R469)

These changes collectively improve the security, configurability, and maintainability of the authentication and logging subsystems.