### PR TITLE
Add support for redirecting back to the current page after login

### DIFF
--- a/src/auth/Auth.php
+++ b/src/auth/Auth.php
@@ -113,8 +113,8 @@ class Auth {
 
             // If redirect_back is requested, build a return URL to the current page and pass it to the auth URL builder
             if ($redirect_back) {
-                $current_url = (is_ssl() ? 'https://' : 'http://') . ($_SERVER['HTTP_HOST'] ?? '') . ($_SERVER['REQUEST_URI'] ?? '/');
-                $current_url = esc_url_raw($current_url);
+                $request_uri = wp_unslash($_SERVER['REQUEST_URI'] ?? '/');
+                $current_url = home_url($request_uri);
                 $login_url = $this->scouting_oidc_auth_login_url($current_url);
             } else {
                 $login_url = $this->scouting_oidc_auth_login_url();
@@ -174,8 +174,8 @@ class Auth {
         }
 
         if ($redirect_back) {
-            $current_url = (is_ssl() ? 'https://' : 'http://') . ($_SERVER['HTTP_HOST'] ?? '') . ($_SERVER['REQUEST_URI'] ?? '/');
-            $current_url = esc_url_raw($current_url);
+            $request_uri = wp_unslash($_SERVER['REQUEST_URI'] ?? '/');
+            $current_url = home_url($request_uri);
             $login_url = $this->scouting_oidc_auth_login_url($current_url);
         } else {
             $login_url = $this->scouting_oidc_auth_login_url();
@@ -249,9 +249,6 @@ class Auth {
             ErrorHandler::redirect_to_login_error('error', __('State is invalid', 'scouting-openid-connect'), 'state_invalid');
         }
 
-        // Apply any per-state redirect into the session so the post-login redirect hook can use it
-        $this->oidc_client->applyRedirectForStateToSession($state);
-
         // Check if 'code' parameter is set in the URL
         if (!filter_has_var(INPUT_GET, 'code')) {
             $this->oidc_client->unsetStatesAndNonce();
@@ -283,11 +280,15 @@ class Auth {
         if ($user->scouting_oidc_user_check_if_exist()) {
             Logger::info(LogComponent::AUTH, "User '{$user->getDisplayName()}' has an existing account, updating user information and logging in", null, $user->getUsername());
             $user->scouting_oidc_user_update();
+            // Promote per-state redirect only after successful callback validation and right before login.
+            $this->oidc_client->applyRedirectForStateToSession($state);
             $user->scouting_oidc_user_login();
         } else {
             if (get_option('scouting_oidc_user_auto_create')) {
                 Logger::info(LogComponent::AUTH, "User '{$user->getDisplayName()}' does not have an account, auto-creation is enabled, creating account and logging in", null, $user->getUsername());
                 $user->scouting_oidc_user_create();
+                // Promote per-state redirect only after successful callback validation and right before login.
+                $this->oidc_client->applyRedirectForStateToSession($state);
                 $user->scouting_oidc_user_login();
             } else {
                 Logger::warning(LogComponent::AUTH, "User '{$user->getDisplayName()}' does not have an account and auto-creation is disabled, redirecting to login page with an error message", null, $user->getUsername());

--- a/src/auth/Auth.php
+++ b/src/auth/Auth.php
@@ -74,11 +74,12 @@ class Auth {
         // Extract shortcode attributes (if any)
         $atts = shortcode_atts(
             array(
-                'width' => '250',                  // Default width in pixels
-                'height' => '40',                  // Default height in pixels
+                'width' => '250',                                // Default width in pixels
+                'height' => '40',                                // Default height in pixels
                 'background_color' => $default_background_color, // Default background color
-                'text_color' => $default_text_color,       // Default text color
-                'hide_logo' => 'false',            // Hide the logo in the button
+                'text_color' => $default_text_color,             // Default text color
+                'hide_logo' => 'false',                          // Hide the logo in the button
+                'redirect_back' => 'false',                      // Redirect back to the current page after login (only applies to the login button, not the logout button)
             ),
             $atts,
             'scouting_oidc_button' // Name of your shortcode
@@ -92,6 +93,7 @@ class Auth {
 
         // Parse boolean-like shortcode attributes (true/false, 1/0, yes/no, on/off)
         $hide_logo = filter_var((string) $atts['hide_logo'], FILTER_VALIDATE_BOOLEAN);
+        $redirect_back = filter_var((string) ($atts['redirect_back'] ?? 'false'), FILTER_VALIDATE_BOOLEAN);
 
         $button_container_id = wp_unique_id('scouting-oidc-login-div-');
         $button_link_id = wp_unique_id('scouting-oidc-login-link-');
@@ -109,7 +111,14 @@ class Auth {
                 return '';
             }
 
-            $login_url = $this->scouting_oidc_auth_login_url();
+            // If redirect_back is requested, build a return URL to the current page and pass it to the auth URL builder
+            if ($redirect_back) {
+                $current_url = (is_ssl() ? 'https://' : 'http://') . ($_SERVER['HTTP_HOST'] ?? '') . ($_SERVER['REQUEST_URI'] ?? '/');
+                $current_url = esc_url_raw($current_url);
+                $login_url = $this->scouting_oidc_auth_login_url($current_url);
+            } else {
+                $login_url = $this->scouting_oidc_auth_login_url();
+            }
 
             // Check if the login URL starts with 'init_error'
             if (substr($login_url, 0, 10) == 'init_error') {
@@ -141,14 +150,30 @@ class Auth {
      * 
      * @return string the HTML for the login URL or an error URL if the login URL cannot be generated
      */
-    public function scouting_oidc_auth_login_url_shortcode(): string {
+    public function scouting_oidc_auth_login_url_shortcode(array $atts = array()): string {
+        // Allow a `redirect_back` attribute for the link shortcode as well
+        $atts = shortcode_atts(
+            array(
+                'redirect_back' => 'false',
+            ),
+            $atts,
+            'scouting_oidc_link'
+        );
+
+        $redirect_back = filter_var((string) ($atts['redirect_back'] ?? 'false'), FILTER_VALIDATE_BOOLEAN);
         // Check if the client ID and client secret are empty 
         if (empty(get_option('scouting_oidc_client_id')) || empty(get_option('scouting_oidc_client_secret'))) {
             Logger::critical(LogComponent::AUTH, "Client ID or Client Secret are missing in the configuration, shortcode login URL will be rendered as an login error URL");
             return ErrorHandler::login_error_url('init', __('Client ID or Client Secret are missing in the configuration', 'scouting-openid-connect'), 'init_error');
         }
 
-        $login_url = $this->scouting_oidc_auth_login_url();
+        if ($redirect_back) {
+            $current_url = (is_ssl() ? 'https://' : 'http://') . ($_SERVER['HTTP_HOST'] ?? '') . ($_SERVER['REQUEST_URI'] ?? '/');
+            $current_url = esc_url_raw($current_url);
+            $login_url = $this->scouting_oidc_auth_login_url($current_url);
+        } else {
+            $login_url = $this->scouting_oidc_auth_login_url();
+        }
 
         // Check if the login URL starts with 'init_error'
         if (substr($login_url, 0, 10) == 'init_error') {
@@ -217,6 +242,9 @@ class Auth {
             $this->oidc_client->unsetStatesAndNonce();
             ErrorHandler::redirect_to_login_error('error', __('State is invalid', 'scouting-openid-connect'), 'state_invalid');
         }
+
+        // Apply any per-state redirect into the session so the post-login redirect hook can use it
+        $this->oidc_client->applyRedirectForStateToSession($state);
 
         // Check if 'code' parameter is set in the URL
         if (!filter_has_var(INPUT_GET, 'code')) {
@@ -320,6 +348,14 @@ class Auth {
      * @return void
      */
     public function scouting_oidc_auth_login_redirect(string $user_login): void {
+        // If a post-login redirect was stored (from a shortcode redirect_back), honor it and exit early
+        $maybe_redirect = $this->oidc_client->getAndClearPostLoginRedirectFromSession();
+        if (is_string($maybe_redirect) && $maybe_redirect !== '') {
+            $safe_redirect = wp_validate_redirect($maybe_redirect, home_url());
+            wp_safe_redirect($safe_redirect);
+            exit;
+        }
+
         $user = get_user_by('login', $user_login);
         if (!$user) return;
 
@@ -453,9 +489,10 @@ class Auth {
     /**
      * Helper function to get the login URL
      * 
+     * @param string|null $redirect_after_login Optional URL to redirect to after login, used for shortcode support. If null, default redirect behavior applies.
      * @return string the login URL
      */
-    private function scouting_oidc_auth_login_url(): string {
+    private function scouting_oidc_auth_login_url(?string $redirect_after_login = null): string {
         $response_type = 'code';
         $scopes = array_map('sanitize_text_field', explode(" ", get_option('scouting_oidc_scopes')));
 
@@ -477,7 +514,7 @@ class Auth {
             }
         }
 
-        return $this->oidc_client->getAuthenticationURL($response_type, $scopes);
+        return $this->oidc_client->getAuthenticationURL($response_type, $scopes, $redirect_after_login);
     }
 }
 ?>

--- a/src/auth/Auth.php
+++ b/src/auth/Auth.php
@@ -161,6 +161,12 @@ class Auth {
         );
 
         $redirect_back = filter_var((string) ($atts['redirect_back'] ?? 'false'), FILTER_VALIDATE_BOOLEAN);
+
+        // If the user is already logged in, return the logout URL instead of the login URL
+        if (is_user_logged_in()) {
+            return esc_url(wp_logout_url(home_url()));
+        }
+
         // Check if the client ID and client secret are empty 
         if (empty(get_option('scouting_oidc_client_id')) || empty(get_option('scouting_oidc_client_secret'))) {
             Logger::critical(LogComponent::AUTH, "Client ID or Client Secret are missing in the configuration, shortcode login URL will be rendered as an login error URL");

--- a/src/auth/OpenIDConnectClient.php
+++ b/src/auth/OpenIDConnectClient.php
@@ -272,6 +272,7 @@ class OpenIDConnectClient
         $this->session->scouting_oidc_session_delete('scouting_oidc_states');
         $this->session->scouting_oidc_session_delete('scouting_oidc_nonces');
         $this->session->scouting_oidc_session_delete('scouting_oidc_code_verifiers');
+        $this->session->scouting_oidc_session_delete('scouting_oidc_post_login_redirect');
 
         Logger::debug(LogComponent::OIDC, 'OIDC state, nonce and PKCE verifier session data cleared');
     }
@@ -863,7 +864,9 @@ class OpenIDConnectClient
 
     /**
      * If a per-state redirect exists, copy it into a single post-login session key and remove the per-state entry.
-     * This makes the redirect available to `wp_login` hooks running later in the same request.
+     *
+     * The value is stored in this plugin's transient-backed session (1 hour TTL), so it may survive
+     * across requests until consumed by `getAndClearPostLoginRedirectFromSession()` or expiration.
      *
      * @param string $state the OIDC state value
      * @return void

--- a/src/auth/OpenIDConnectClient.php
+++ b/src/auth/OpenIDConnectClient.php
@@ -106,9 +106,10 @@ class OpenIDConnectClient
      * 
      * @param string $response_type the response type
      * @param array $scopes_array an array of scopes
+     * @param string|null $redirect_after_login Optional URL to redirect to after login, used for shortcode support. If null, default redirect behavior applies.
      * @return string the authentication URL
      */
-    public function getAuthenticationURL(string $response_type, array $scopes_array): string {
+    public function getAuthenticationURL(string $response_type, array $scopes_array, ?string $redirect_after_login = null): string {
         Logger::debug(LogComponent::OIDC, 'Authentication URL generation started');
         $this->getWellKnownData();
         $this->getJWKSData();
@@ -164,6 +165,12 @@ class OpenIDConnectClient
             'code_challenge' => $code_challenge,
             'code_challenge_method' => 'S256',
         ];
+
+        // If a specific post-login redirect was requested (e.g. shortcode redirect_back), store it keyed by state
+        if (is_string($redirect_after_login) && $redirect_after_login !== '') {
+            $redirect_after_login = esc_url_raw($redirect_after_login);
+            $this->setRedirectForState($state, $redirect_after_login);
+        }
 
         Logger::debug(LogComponent::OIDC, 'Authentication URL generated successfully');
 
@@ -801,6 +808,86 @@ class OpenIDConnectClient
         $this->session->scouting_oidc_session_set('scouting_oidc_code_verifiers', $verifiers);
 
         return $code_verifier;
+    }
+
+    /**
+     * Store a post-login redirect target keyed by state in the session
+     *
+     * @param string $state the OIDC state value
+     * @param string $redirect_url the URL to redirect to after login is complete.
+     * @return void
+     */
+    private function setRedirectForState(string $state, string $redirect_url): void {
+        $redirects = $this->session->scouting_oidc_session_get('scouting_oidc_redirects') ?? [];
+        if (!is_array($redirects)) {
+            $redirects = [];
+        }
+
+        $redirects[$state] = $redirect_url;
+        $this->session->scouting_oidc_session_set('scouting_oidc_redirects', $redirects);
+    }
+
+    /**
+     * Retrieve the stored redirect for a given state
+     *
+     * @param string $state the OIDC state value
+     * @return string|null the redirect URL if found, or null if not found or invalid.
+     */
+    public function getRedirectForState(string $state): ?string {
+        $redirects = $this->session->scouting_oidc_session_get('scouting_oidc_redirects');
+        if (!is_array($redirects)) {
+            return null;
+        }
+
+        $redirect = $redirects[$state] ?? null;
+        return is_string($redirect) && $redirect !== '' ? $redirect : null;
+    }
+
+    /**
+     * Remove the stored redirect for a given state
+     *
+     * @param string $state the OIDC state value
+     * @return void
+     */
+    private function deleteRedirectForState(string $state): void {
+        $redirects = $this->session->scouting_oidc_session_get('scouting_oidc_redirects') ?? [];
+        if (!is_array($redirects)) {
+            return;
+        }
+
+        if (array_key_exists($state, $redirects)) {
+            unset($redirects[$state]);
+            $this->session->scouting_oidc_session_set('scouting_oidc_redirects', $redirects);
+        }
+    }
+
+    /**
+     * If a per-state redirect exists, copy it into a single post-login session key and remove the per-state entry.
+     * This makes the redirect available to `wp_login` hooks running later in the same request.
+     *
+     * @param string $state the OIDC state value
+     * @return void
+     */
+    public function applyRedirectForStateToSession(string $state): void {
+        $redirect = $this->getRedirectForState($state);
+        if ($redirect !== null) {
+            $this->session->scouting_oidc_session_set('scouting_oidc_post_login_redirect', $redirect);
+            $this->deleteRedirectForState($state);
+        }
+    }
+
+    /**
+     * Retrieve and clear the post-login redirect stored in session.
+     *
+     * @return string|null the redirect URL if found, or null if not found or invalid.
+     */
+    public function getAndClearPostLoginRedirectFromSession(): ?string {
+        $redirect = $this->session->scouting_oidc_session_get('scouting_oidc_post_login_redirect');
+        if (!is_string($redirect) || $redirect === '') {
+            return null;
+        }
+        $this->session->scouting_oidc_session_delete('scouting_oidc_post_login_redirect');
+        return esc_url_raw($redirect);
     }
 
     /**

--- a/src/shortcode/Page.php
+++ b/src/shortcode/Page.php
@@ -68,7 +68,7 @@ class Shortcode
                         <li><code>redirect_back</code>: <?php esc_html_e('Set to true to return the user to the page with the button after login. This overrides login redirection settings.', 'scouting-openid-connect'); ?></li>
                     </ul>
                 </div>
-                <div style="float: left; width: 50%; padding-left: 10px; border-left: 2px solid #8c8f94;box-sizing: border-box;">
+                <div style="float: left; width: 50%; padding-left: 10px; border-left: 2px solid #8c8f94; box-sizing: border-box;">
                     <h4><?php esc_html_e('Live Shortcode Editor', 'scouting-openid-connect'); ?></h4>
                     <form>
                         <label for="scoutingOIDCWidthInput">Width</label>

--- a/src/shortcode/Page.php
+++ b/src/shortcode/Page.php
@@ -122,6 +122,7 @@ class Shortcode
             </p>
             <pre><code id="scoutingOIDCLinkShortCode">[scouting_oidc_link]</code></pre>
             <p><?php esc_html_e('You can not customize the appearance of the link, but you can add redirect_back="true" to return the user to the current page after login.', 'scouting-openid-connect'); ?></p>
+            <p><?php esc_html_e('Example of the link shortcode:', 'scouting-openid-connect'); ?></p>
             <p><?php echo do_shortcode('[scouting_oidc_link]'); ?><br><strong><?php esc_html_e('Note: Do not copy this link, it will not work. This is just an example of how the link will look like.', 'scouting-openid-connect'); ?></strong></p>
         </div>
         <?php

--- a/src/shortcode/Page.php
+++ b/src/shortcode/Page.php
@@ -50,7 +50,7 @@ class Shortcode
             <hr class="scouting-oidc-divider" style="border-top: 2px solid #8c8f94; border-radius: 4px; margin: 20px 0px;"/>
             <h3 id="openid-button"><?php esc_html_e('OpenID Connect Button', 'scouting-openid-connect'); ?></h3>
             <div style='content: ""; display: table; clear: both;'>
-                <div style="float: left; width: 50%; padding-right: 10px; border-right: 2px solid #8c8f94; box-sizing: border-box;">
+                <div style="float: left; width: 50%; padding-right: 10px; box-sizing: border-box;">
                     <h4><?php esc_html_e('Button Example', 'scouting-openid-connect'); ?></h4>
                     <p>
                         <?php esc_html_e('The OpenID Connect button shortcode allows you to add a button to your WordPress site that users can click to log in using their Scouts Online account.', 'scouting-openid-connect'); ?>
@@ -65,9 +65,10 @@ class Shortcode
                         <li><code>background_color</code>: <?php esc_html_e('The background color of the button.', 'scouting-openid-connect'); ?></li>
                         <li><code>text_color</code>: <?php esc_html_e('The text color of the button.', 'scouting-openid-connect'); ?></li>
                         <li><code>hide_logo</code>: <?php esc_html_e('Set to true to hide the logo.', 'scouting-openid-connect'); ?></li>
+                        <li><code>redirect_back</code>: <?php esc_html_e('Set to true to return the user to the page with the button after login. This overrides login redirection settings.', 'scouting-openid-connect'); ?></li>
                     </ul>
                 </div>
-                <div style="float: left; width: 50%; padding-left: 10px; box-sizing: border-box;">
+                <div style="float: left; width: 50%; padding-left: 10px; border-left: 2px solid #8c8f94;box-sizing: border-box;">
                     <h4><?php esc_html_e('Live Shortcode Editor', 'scouting-openid-connect'); ?></h4>
                     <form>
                         <label for="scoutingOIDCWidthInput">Width</label>
@@ -89,6 +90,10 @@ class Shortcode
                         <label for="scoutingOIDCHideLogoInput">Hide Logo</label>
                         <input type="checkbox" id="scoutingOIDCHideLogoInput">
                         <p class="description"><?php esc_html_e('Check this box to hide the logo on the button.', 'scouting-openid-connect'); ?></p>
+
+                        <label for="scoutingOIDCRedirectBackInput">Redirect Back</label>
+                        <input type="checkbox" id="scoutingOIDCRedirectBackInput">
+                        <p class="description"><?php esc_html_e('Check this box to add redirect_back="true" to the generated shortcodes.', 'scouting-openid-connect'); ?></p>
 
                         <label for="scoutingOIDCDemoLogoutInput">Preview Logout Button</label>
                         <input type="checkbox" id="scoutingOIDCDemoLogoutInput">
@@ -115,9 +120,8 @@ class Shortcode
                 <br>
                 <?php esc_html_e('To add the OpenID Connect link to your site, use the following shortcode:', 'scouting-openid-connect'); ?>
             </p>
-            <pre><code>[scouting_oidc_link]</code></pre>
-            <p><?php esc_html_e('You can not customize the appearance of the link.', 'scouting-openid-connect'); ?></p>
-            <p><?php esc_html_e('Example of the link shortcode:', 'scouting-openid-connect'); ?></p>
+            <pre><code id="scoutingOIDCLinkShortCode">[scouting_oidc_link]</code></pre>
+            <p><?php esc_html_e('You can not customize the appearance of the link, but you can add redirect_back="true" to return the user to the current page after login.', 'scouting-openid-connect'); ?></p>
             <p><?php echo do_shortcode('[scouting_oidc_link]'); ?><br><strong><?php esc_html_e('Note: Do not copy this link, it will not work. This is just an example of how the link will look like.', 'scouting-openid-connect'); ?></strong></p>
         </div>
         <?php

--- a/src/shortcode/Page.php
+++ b/src/shortcode/Page.php
@@ -121,7 +121,7 @@ class Shortcode
                 <?php esc_html_e('To add the OpenID Connect link to your site, use the following shortcode:', 'scouting-openid-connect'); ?>
             </p>
             <pre><code id="scoutingOIDCLinkShortCode">[scouting_oidc_link]</code></pre>
-            <p><?php esc_html_e('You can not customize the appearance of the link, but you can add redirect_back="true" to return the user to the current page after login.', 'scouting-openid-connect'); ?></p>
+            <p><?php esc_html_e('You cannot customize the appearance of the link, but you can add redirect_back="true" to return the user to the current page after login.', 'scouting-openid-connect'); ?></p>
             <p><?php esc_html_e('Example of the link shortcode:', 'scouting-openid-connect'); ?></p>
             <p><?php echo do_shortcode('[scouting_oidc_link]'); ?><br><strong><?php esc_html_e('Note: Do not copy this link, it will not work. This is just an example of how the link will look like.', 'scouting-openid-connect'); ?></strong></p>
         </div>

--- a/src/shortcode/live-shortcode.js
+++ b/src/shortcode/live-shortcode.js
@@ -34,6 +34,7 @@ function initializeLiveShortcodeEditor() {
     registerEventListeners(elements, state);
 
     updateShortcodeText(elements, state);
+    updateLinkShortcodeText(elements, state);
     updateDemoLogoutPreview(elements, state);
     updateLogoVisibility(elements, state);
 
@@ -190,7 +191,6 @@ function updateDemoLogoutPreview(elements, state) {
 
 function updateShortcodeText(elements, state) {
     elements.shortcodeText.textContent = buildShortcodeText(elements, state);
-    updateLinkShortcodeText(elements, state);
 }
 
 function updateLinkShortcodeText(elements, state) {

--- a/src/shortcode/live-shortcode.js
+++ b/src/shortcode/live-shortcode.js
@@ -3,6 +3,7 @@ const DEFAULT_SHORTCODE_VALUES = Object.freeze({
     height: '40',
     backgroundColor: '#4caf50',
     textColor: '#ffffff',
+    redirectBack: false,
 });
 
 const MIN_DIMENSIONS = Object.freeze({
@@ -25,10 +26,11 @@ function initializeLiveShortcodeEditor() {
         logoutButtonText: buttonTextLabels.logoutButtonText,
         lastValidWidth: getInitialDimensionValue(elements.widthInput.value, MIN_DIMENSIONS.width, DEFAULT_SHORTCODE_VALUES.width),
         lastValidHeight: getInitialDimensionValue(elements.heightInput.value, MIN_DIMENSIONS.height, DEFAULT_SHORTCODE_VALUES.height),
+        redirectBack: false,
         loginImgBackup: null,
     };
 
-    initializeEditorInputs(elements);
+    initializeEditorInputs(elements, state);
     registerEventListeners(elements, state);
 
     updateShortcodeText(elements, state);
@@ -48,7 +50,9 @@ function getLiveShortcodeElements() {
         textColorInput: document.getElementById('scoutingOIDCTextColorInput'),
         hideLogoInput: document.getElementById('scoutingOIDCHideLogoInput'),
         demoLogoutInput: document.getElementById('scoutingOIDCDemoLogoutInput'),
+        redirectBackInput: document.getElementById('scoutingOIDCRedirectBackInput'),
         shortcodeText: document.getElementById('scoutingOIDCButtonShortCode'),
+        linkShortcodeText: document.getElementById('scoutingOIDCLinkShortCode'),
         button: previewContainer ? previewContainer.querySelector('.scouting-oidc-login-div, #scouting-oidc-login-div') : null,
         loginLink: previewContainer ? previewContainer.querySelector('.scouting-oidc-login-link, #scouting-oidc-login-link') : null,
         loginText: previewContainer ? previewContainer.querySelector('.scouting-oidc-login-text, #scouting-oidc-login-text') : null,
@@ -63,7 +67,9 @@ function hasRequiredElements(elements) {
             && elements.textColorInput
             && elements.hideLogoInput
             && elements.demoLogoutInput
+            && elements.redirectBackInput
             && elements.shortcodeText
+            && elements.linkShortcodeText
             && elements.button
             && elements.loginLink
             && elements.loginText
@@ -79,9 +85,11 @@ function getButtonTextLabels() {
     };
 }
 
-function initializeEditorInputs(elements) {
+function initializeEditorInputs(elements, state) {
     elements.hideLogoInput.checked = /hide_logo="true"/.test(elements.shortcodeText.textContent);
     elements.demoLogoutInput.checked = false;
+    elements.redirectBackInput.checked = false;
+    state.redirectBack = elements.redirectBackInput.checked;
 }
 
 function registerEventListeners(elements, state) {
@@ -102,6 +110,11 @@ function registerEventListeners(elements, state) {
     });
     elements.demoLogoutInput.addEventListener('change', () => {
         updateDemoLogoutPreview(elements, state);
+    });
+    elements.redirectBackInput.addEventListener('change', () => {
+        state.redirectBack = elements.redirectBackInput.checked;
+        updateShortcodeText(elements, state);
+        updateLinkShortcodeText(elements, state);
     });
 }
 
@@ -177,6 +190,15 @@ function updateDemoLogoutPreview(elements, state) {
 
 function updateShortcodeText(elements, state) {
     elements.shortcodeText.textContent = buildShortcodeText(elements, state);
+    updateLinkShortcodeText(elements, state);
+}
+
+function updateLinkShortcodeText(elements, state) {
+    if (!elements.linkShortcodeText) {
+        return;
+    }
+
+    elements.linkShortcodeText.textContent = buildLinkShortcodeText(state);
 }
 
 function buildShortcodeText(elements, state) {
@@ -216,11 +238,19 @@ function buildShortcodeText(elements, state) {
         shortcodeAttributes.push('hide_logo="true"');
     }
 
+    if (state.redirectBack) {
+        shortcodeAttributes.push('redirect_back="true"');
+    }
+
     if (shortcodeAttributes.length === 0) {
         return '[scouting_oidc_button]';
     }
 
     return `[scouting_oidc_button ${shortcodeAttributes.join(' ')}]`;
+}
+
+function buildLinkShortcodeText(state) {
+    return state.redirectBack ? '[scouting_oidc_link redirect_back="true"]' : '[scouting_oidc_link]';
 }
 
 function updateLogoVisibility(elements, state) {


### PR DESCRIPTION
- Introduced `redirect_back` attribute for shortcodes to allow users to return to the page with the button after login.
- Updated `Auth` class to handle redirect logic based on the new attribute.
- Enhanced `OpenIDConnectClient` to store and retrieve redirect URLs keyed by state.
- Modified live shortcode editor to include a checkbox for the `redirect_back` option.