### PR TITLE
Add user sub check

### DIFF
--- a/.github/workflows/release-zip.yml
+++ b/.github/workflows/release-zip.yml
@@ -31,6 +31,8 @@ jobs:
             --exclude ".github" \
             --exclude ".gitattributes" \
             --exclude "CHANGELOG.md" \
+            --exclude "SECURITY.md" \
+            --exclude "CONTRIBUTING.md" \
             --exclude "README.md" \
             --include "assets/" \
             --include "assets/icon.svg" \

--- a/.github/workflows/release-zip.yml
+++ b/.github/workflows/release-zip.yml
@@ -13,7 +13,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v7.0.1
         with:
           fetch-depth: 0
 
@@ -50,7 +50,7 @@ jobs:
           if-no-files-found: error
 
       - name: Attach zip to release
-        uses: softprops/action-gh-release@v3.0.0
+        uses: softprops/action-gh-release@v3.0.2
         with:
           files: ${{ env.ZIP_PATH }}
           generate_release_notes: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,38 @@
+# Contributing to Scouting OpenID Connect
+
+Thank you for helping improve the Scouting OpenID Connect WordPress plugin.
+
+## Where to Contribute
+
+- Report reproducible plugin bugs through the [bug report form](https://github.com/Scouting-nl/scouting-openid-connect/issues/new/choose).
+- Ask for help through the [support discussions](https://github.com/scouting-nl/scouting-openid-connect/discussions/categories/support).
+- Share feature requests and ideas through the [ideas discussions](https://github.com/scouting-nl/scouting-openid-connect/discussions/categories/ideas).
+- Report security vulnerabilities privately according to [SECURITY.md](SECURITY.md). Do not open a public issue or discussion for a suspected vulnerability.
+
+Do not include client secrets, access tokens, ID tokens, passwords, personal data, or production logs in issues, pull requests, or discussions.
+
+## Development
+
+Use a WordPress test installation and a client configuration that you are authorized to use. Refer to [README.md](README.md) for the required plugin configuration and supported WordPress and PHP versions.
+
+Keep changes focused and consistent with the existing WordPress coding and security practices. In particular:
+
+- Sanitize input, validate authorization and nonces where applicable, and escape output in its rendering context.
+- Preserve the OpenID Connect protections around state, nonce, PKCE, and session handling.
+- Update translations when changing user-facing strings.
+- Update [README.md](README.md), [CHANGELOG.md](CHANGELOG.md), or other documentation when user-visible behavior or configuration changes.
+
+## Pull Requests
+
+Before opening a pull request:
+
+- Start from the latest default branch and keep unrelated changes out of the pull request.
+- Add or update focused tests when practical, and describe the validation you performed.
+- Explain the problem, the chosen solution, and any configuration, upgrade, or compatibility impact.
+- Do not commit generated ZIP files, credentials, or environment-specific files.
+
+GitHub Actions runs the WordPress Plugin Check on pushes and pull requests. Ensure that check passes before requesting review.
+
+## Reviews and Releases
+
+Maintainers review pull requests for behavior, security, backward compatibility, and WordPress Plugin Check results. Releases are created by maintainers from version tags; contributors should not prepare release archives unless requested.

--- a/src/auth/Auth.php
+++ b/src/auth/Auth.php
@@ -295,11 +295,15 @@ class Auth {
                 ErrorHandler::redirect_to_login_error('error', __('Webmaster disabled creation of new accounts', 'scouting-openid-connect'), 'disabled_auto_create');
             }
         }
+
+        // Configured post-login redirects exit from the wp_login hook. Clean OIDC callback parameters for the default flow.
+        wp_safe_redirect(home_url('/'));
+        exit;
     }
 
     /**
      * Callback after failed login
-     * 
+     *
      * @param string $message the error message
      * @return string the HTML for the error message or an empty string if the user is not logged in
      */

--- a/src/auth/Auth.php
+++ b/src/auth/Auth.php
@@ -113,7 +113,7 @@ class Auth {
 
             // If redirect_back is requested, build a return URL to the current page and pass it to the auth URL builder
             if ($redirect_back) {
-                $request_uri = wp_unslash($_SERVER['REQUEST_URI'] ?? '/');
+                $request_uri = isset($_SERVER['REQUEST_URI']) ? esc_url_raw(wp_unslash($_SERVER['REQUEST_URI'])) : '/';
                 $current_url = home_url($request_uri);
                 $login_url = $this->scouting_oidc_auth_login_url($current_url);
             } else {
@@ -174,7 +174,7 @@ class Auth {
         }
 
         if ($redirect_back) {
-            $request_uri = wp_unslash($_SERVER['REQUEST_URI'] ?? '/');
+            $request_uri = isset($_SERVER['REQUEST_URI']) ? esc_url_raw(wp_unslash($_SERVER['REQUEST_URI'])) : '/';
             $current_url = home_url($request_uri);
             $login_url = $this->scouting_oidc_auth_login_url($current_url);
         } else {

--- a/src/auth/OpenIDConnectClient.php
+++ b/src/auth/OpenIDConnectClient.php
@@ -877,6 +877,8 @@ class OpenIDConnectClient
             $this->session->scouting_oidc_session_set('scouting_oidc_post_login_redirect', $redirect);
             $this->deleteRedirectForState($state);
         }
+
+        $this->session->scouting_oidc_session_regenerate_id();
     }
 
     /**

--- a/src/auth/OpenIDConnectClient.php
+++ b/src/auth/OpenIDConnectClient.php
@@ -84,7 +84,7 @@ class OpenIDConnectClient
 
     /**
      * OpenIDConnectClient constructor
-     * 
+     *
      * @param string $client_id
      * @param string $client_secret
      * @param string $redirect_uri
@@ -103,13 +103,22 @@ class OpenIDConnectClient
 
     /**
      * Generates the authentication URL
-     * 
+     *
      * @param string $response_type the response type
      * @param array $scopes_array an array of scopes
      * @param string|null $redirect_after_login Optional URL to redirect to after login, used for shortcode support. If null, default redirect behavior applies.
      * @return string the authentication URL
      */
     public function getAuthenticationURL(string $response_type, array $scopes_array, ?string $redirect_after_login = null): string {
+        if (!$this->session->scouting_oidc_session_set_session_id()) {
+            Logger::critical(LogComponent::OIDC, 'A secure OIDC session cookie could not be created.');
+            ErrorHandler::redirect_to_login_error(
+                'init',
+                __('A secure login session could not be started. Please use HTTPS and try again.', 'scouting-openid-connect'),
+                'session_cookie_unavailable'
+            );
+        }
+
         Logger::debug(LogComponent::OIDC, 'Authentication URL generation started');
         $this->getWellKnownData();
         $this->getJWKSData();
@@ -878,7 +887,14 @@ class OpenIDConnectClient
             $this->deleteRedirectForState($state);
         }
 
-        $this->session->scouting_oidc_session_regenerate_id();
+        if (!$this->session->scouting_oidc_session_regenerate_id()) {
+            Logger::critical(LogComponent::OIDC, 'A secure OIDC session cookie could not be created.');
+            ErrorHandler::redirect_to_login_error(
+                'init',
+                __('A secure login session could not be started. Please use HTTPS and try again.', 'scouting-openid-connect'),
+                'session_cookie_unavailable'
+            );
+        }
     }
 
     /**

--- a/src/auth/OpenIDConnectClient.php
+++ b/src/auth/OpenIDConnectClient.php
@@ -96,9 +96,8 @@ class OpenIDConnectClient
         $this->redirectURL = trailingslashit($redirect_uri);
         $this->issuer = $scouting_issuer;
 
-        // Load session to store tokens if needed
+        // Initialize session storage; create the cookie only when login begins.
         $this->session = new Session();
-        $this->session->scouting_oidc_session_set_session_id();
     }
 
     /**

--- a/src/auth/Session.php
+++ b/src/auth/Session.php
@@ -18,7 +18,12 @@ class Session {
      * @param mixed $value the value to set in the transient session
      */
     public function scouting_oidc_session_set(string $key, mixed $value): void {
-        set_transient('scouting_oidc_session_'.$this->scouting_oidc_session_get_session_id().'_'.$key, $value, HOUR_IN_SECONDS);
+        $session_id = $this->scouting_oidc_session_get_session_id();
+        if ($session_id === '') {
+            return;
+        }
+
+        set_transient($this->transientKey($session_id, $key), $value, HOUR_IN_SECONDS);
     }
 
     /**
@@ -28,8 +33,12 @@ class Session {
      * @return mixed the value from the transient session
      */
     public function scouting_oidc_session_get(string $key): mixed {
-        $value = get_transient('scouting_oidc_session_'.$this->scouting_oidc_session_get_session_id().'_'.$key);
-        return $value;
+        $session_id = $this->scouting_oidc_session_get_session_id();
+        if ($session_id === '') {
+            return false;
+        }
+
+        return get_transient($this->transientKey($session_id, $key));
     }
 
     /**
@@ -38,39 +47,59 @@ class Session {
      * @param string $key the key to delete from the transient session
      */
     public function scouting_oidc_session_delete(string $key): void {
-        delete_transient('scouting_oidc_session_'.$this->scouting_oidc_session_get_session_id().'_'.$key);
+        $session_id = $this->scouting_oidc_session_get_session_id();
+        if ($session_id === '') {
+            return;
+        }
+
+        delete_transient($this->transientKey($session_id, $key));
     }
 
     /**
-     * Set a user unique session ID named 'scouting_oidc_session' with a 1 hour expiration time
+     * Set a unique session ID in the __Host-scouting_oidc_session cookie for 1 hour.
+     *
+     * @return bool True when a persistent session cookie is available
      */
-    public function scouting_oidc_session_set_session_id(): void {
+    public function scouting_oidc_session_set_session_id(): bool {
         $session_id = $this->scouting_oidc_session_get_session_id();
-        if (empty($session_id)) {
-            $this->scouting_oidc_session_set_cookie(bin2hex(random_bytes(16)));
+        if ($session_id !== '') {
+            return true;
         }
+
+        return $this->scouting_oidc_session_set_cookie(bin2hex(random_bytes(16)));
     }
 
     /**
      * Rotate the session ID after authentication and discard pre-login state.
+     *
+     * @return bool True when the session ID was rotated
      */
-    public function scouting_oidc_session_regenerate_id(): void {
+    public function scouting_oidc_session_regenerate_id(): bool {
+        $old_session_id = $this->scouting_oidc_session_get_session_id();
+        if ($old_session_id === '') {
+            return false;
+        }
+
         $preserved = array(
             'scouting_oidc_id_token' => $this->scouting_oidc_session_get('scouting_oidc_id_token'),
             'scouting_oidc_post_login_redirect' => $this->scouting_oidc_session_get('scouting_oidc_post_login_redirect'),
         );
 
-        foreach (array('scouting_oidc_redirect_uri', 'scouting_oidc_states', 'scouting_oidc_nonces', 'scouting_oidc_code_verifiers', 'scouting_oidc_post_login_redirect', 'scouting_oidc_redirects', 'scouting_oidc_id_token') as $key) {
-            $this->scouting_oidc_session_delete($key);
+        if (!$this->scouting_oidc_session_set_cookie(bin2hex(random_bytes(16)))) {
+            return false;
         }
 
-        $this->scouting_oidc_session_set_cookie(bin2hex(random_bytes(16)));
+        foreach (array('scouting_oidc_redirect_uri', 'scouting_oidc_states', 'scouting_oidc_nonces', 'scouting_oidc_code_verifiers', 'scouting_oidc_post_login_redirect', 'scouting_oidc_redirects', 'scouting_oidc_id_token') as $key) {
+            delete_transient($this->transientKey($old_session_id, $key));
+        }
 
         foreach ($preserved as $key => $value) {
             if ($value !== false) {
                 $this->scouting_oidc_session_set($key, $value);
             }
         }
+
+        return true;
     }
 
     /**
@@ -79,6 +108,10 @@ class Session {
      * @return string the session ID value or an empty string if the session ID does not exist
      */
     private function scouting_oidc_session_get_session_id(): string {
+        if (!is_ssl()) {
+            return '';
+        }
+
         $session_id = isset($_COOKIE[self::COOKIE_NAME]) ? sanitize_text_field(wp_unslash($_COOKIE[self::COOKIE_NAME])) : '';
         if (is_string($session_id) && preg_match('/\A[a-f0-9]{32}\z/', $session_id) === 1) {
             return $session_id;
@@ -91,19 +124,38 @@ class Session {
      * Set a host-only secure session cookie and expose it to the current request.
      *
      * @param string $session_id Session identifier
+     * @return bool True when the cookie was successfully queued
      */
-    private function scouting_oidc_session_set_cookie(string $session_id): void {
-        if (!headers_sent()) {
-            setcookie(self::COOKIE_NAME, $session_id, [
-                'expires' => time() + HOUR_IN_SECONDS,
-                'path' => '/',
-                'secure' => true,
-                'httponly' => true,
-                'samesite' => 'Lax'
-            ]);
+    private function scouting_oidc_session_set_cookie(string $session_id): bool {
+        if (!is_ssl() || headers_sent()) {
+            return false;
+        }
+
+        $was_set = setcookie(self::COOKIE_NAME, $session_id, [
+            'expires' => time() + HOUR_IN_SECONDS,
+            'path' => '/',
+            'secure' => true,
+            'httponly' => true,
+            'samesite' => 'Lax'
+        ]);
+
+        if (!$was_set) {
+            return false;
         }
 
         $_COOKIE[self::COOKIE_NAME] = $session_id;
+        return true;
+    }
+
+    /**
+     * Build the transient key for a validated session identifier.
+     *
+     * @param string $session_id Session identifier
+     * @param string $key Session data key
+     * @return string Transient key
+     */
+    private function transientKey(string $session_id, string $key): string {
+        return 'scouting_oidc_session_'.$session_id.'_'.$key;
     }
 }
 ?>

--- a/src/auth/Session.php
+++ b/src/auth/Session.php
@@ -79,7 +79,7 @@ class Session {
      * @return string the session ID value or an empty string if the session ID does not exist
      */
     private function scouting_oidc_session_get_session_id(): string {
-        $session_id = isset($_COOKIE[self::COOKIE_NAME]) ? wp_unslash($_COOKIE[self::COOKIE_NAME]) : '';
+        $session_id = isset($_COOKIE[self::COOKIE_NAME]) ? sanitize_text_field(wp_unslash($_COOKIE[self::COOKIE_NAME])) : '';
         if (is_string($session_id) && preg_match('/\A[a-f0-9]{32}\z/', $session_id) === 1) {
             return $session_id;
         }

--- a/src/auth/Session.php
+++ b/src/auth/Session.php
@@ -9,6 +9,8 @@ if ( ! defined( 'HOUR_IN_SECONDS' ) ) {
 }
 
 class Session {
+    private const COOKIE_NAME = '__Host-scouting_oidc_session';
+
     /**
      * Sets value in a transient session for 1 hour
      * 
@@ -45,25 +47,29 @@ class Session {
     public function scouting_oidc_session_set_session_id(): void {
         $session_id = $this->scouting_oidc_session_get_session_id();
         if (empty($session_id)) {
-            $session_id = bin2hex(random_bytes(16));
+            $this->scouting_oidc_session_set_cookie(bin2hex(random_bytes(16)));
+        }
+    }
 
-            // Get the domain for the cookie
-            $domain = wp_parse_url(home_url(), PHP_URL_HOST);
-            if (empty( $domain )) {
-                $domain = '';
+    /**
+     * Rotate the session ID after authentication and discard pre-login state.
+     */
+    public function scouting_oidc_session_regenerate_id(): void {
+        $preserved = array(
+            'scouting_oidc_id_token' => $this->scouting_oidc_session_get('scouting_oidc_id_token'),
+            'scouting_oidc_post_login_redirect' => $this->scouting_oidc_session_get('scouting_oidc_post_login_redirect'),
+        );
+
+        foreach (array('scouting_oidc_redirect_uri', 'scouting_oidc_states', 'scouting_oidc_nonces', 'scouting_oidc_code_verifiers', 'scouting_oidc_post_login_redirect', 'scouting_oidc_redirects', 'scouting_oidc_id_token') as $key) {
+            $this->scouting_oidc_session_delete($key);
+        }
+
+        $this->scouting_oidc_session_set_cookie(bin2hex(random_bytes(16)));
+
+        foreach ($preserved as $key => $value) {
+            if ($value !== false) {
+                $this->scouting_oidc_session_set($key, $value);
             }
-
-            setcookie('scouting_oidc_session', $session_id, [
-                'expires' => time() + HOUR_IN_SECONDS,
-                'path' => '/',
-                'domain' => $domain,
-                'secure' => is_ssl(),
-                'httponly' => true,
-                'samesite' => 'Lax'
-            ]);
-
-            // Make the new session ID visible to this request so transients use the same session id
-            $_COOKIE['scouting_oidc_session'] = $session_id;
         }
     }
 
@@ -73,14 +79,29 @@ class Session {
      * @return string the session ID value or an empty string if the session ID does not exist
      */
     private function scouting_oidc_session_get_session_id(): string {
-        // Check if the cookie exists
-        if (isset($_COOKIE['scouting_oidc_session'])) {
-            // Unslash the cookie value and sanitize it
-            return sanitize_text_field(wp_unslash($_COOKIE['scouting_oidc_session']));
+        $session_id = isset($_COOKIE[self::COOKIE_NAME]) ? wp_unslash($_COOKIE[self::COOKIE_NAME]) : '';
+        if (is_string($session_id) && preg_match('/\A[a-f0-9]{32}\z/', $session_id) === 1) {
+            return $session_id;
         }
-        
-        // Return empty string if the cookie does not exist
+
         return '';
+    }
+
+    /**
+     * Set a host-only secure session cookie and expose it to the current request.
+     *
+     * @param string $session_id Session identifier
+     */
+    private function scouting_oidc_session_set_cookie(string $session_id): void {
+        setcookie(self::COOKIE_NAME, $session_id, [
+            'expires' => time() + HOUR_IN_SECONDS,
+            'path' => '/',
+            'secure' => true,
+            'httponly' => true,
+            'samesite' => 'Lax'
+        ]);
+
+        $_COOKIE[self::COOKIE_NAME] = $session_id;
     }
 }
 ?>

--- a/src/auth/Session.php
+++ b/src/auth/Session.php
@@ -93,13 +93,15 @@ class Session {
      * @param string $session_id Session identifier
      */
     private function scouting_oidc_session_set_cookie(string $session_id): void {
-        setcookie(self::COOKIE_NAME, $session_id, [
-            'expires' => time() + HOUR_IN_SECONDS,
-            'path' => '/',
-            'secure' => true,
-            'httponly' => true,
-            'samesite' => 'Lax'
-        ]);
+        if (!headers_sent()) {
+            setcookie(self::COOKIE_NAME, $session_id, [
+                'expires' => time() + HOUR_IN_SECONDS,
+                'path' => '/',
+                'secure' => true,
+                'httponly' => true,
+                'samesite' => 'Lax'
+            ]);
+        }
 
         $_COOKIE[self::COOKIE_NAME] = $session_id;
     }

--- a/src/auth/Session.php
+++ b/src/auth/Session.php
@@ -66,7 +66,8 @@ class Session {
             return true;
         }
 
-        return $this->scouting_oidc_session_set_cookie(bin2hex(random_bytes(16)));
+        $session_id = $this->generateSessionId();
+        return $session_id !== null && $this->scouting_oidc_session_set_cookie($session_id);
     }
 
     /**
@@ -85,7 +86,8 @@ class Session {
             'scouting_oidc_post_login_redirect' => $this->scouting_oidc_session_get('scouting_oidc_post_login_redirect'),
         );
 
-        if (!$this->scouting_oidc_session_set_cookie(bin2hex(random_bytes(16)))) {
+        $session_id = $this->generateSessionId();
+        if ($session_id === null || !$this->scouting_oidc_session_set_cookie($session_id)) {
             return false;
         }
 
@@ -145,6 +147,19 @@ class Session {
 
         $_COOKIE[self::COOKIE_NAME] = $session_id;
         return true;
+    }
+
+    /**
+     * Generate a cryptographically secure session identifier.
+     *
+     * @return string|null Session identifier, or null when secure randomness is unavailable
+     */
+    private function generateSessionId(): ?string {
+        try {
+            return bin2hex(random_bytes(16));
+        } catch (\Exception $exception) {
+            return null;
+        }
     }
 
     /**

--- a/src/auth/Session.php
+++ b/src/auth/Session.php
@@ -13,7 +13,7 @@ class Session {
 
     /**
      * Sets value in a transient session for 1 hour
-     * 
+     *
      * @param string $key the key to set in the transient session
      * @param mixed $value the value to set in the transient session
      */
@@ -23,7 +23,7 @@ class Session {
 
     /**
      * Gets value from the transient session
-     * 
+     *
      * @param string $key the key to get from the transient session
      * @return mixed the value from the transient session
      */
@@ -34,7 +34,7 @@ class Session {
 
     /**
      * Delete value from the transient session
-     * 
+     *
      * @param string $key the key to delete from the transient session
      */
     public function scouting_oidc_session_delete(string $key): void {
@@ -75,7 +75,7 @@ class Session {
 
     /**
      * Get the scouting_oidc_session session ID value
-     * 
+     *
      * @return string the session ID value or an empty string if the session ID does not exist
      */
     private function scouting_oidc_session_get_session_id(): string {

--- a/src/settings/Oidc.php
+++ b/src/settings/Oidc.php
@@ -192,7 +192,7 @@ class Settings_Oidc
             $allowed_scopes_safe = array_map(static fn($scope) => esc_html(sanitize_text_field((string) $scope)), $allowed_scopes);
             $unsupported_list = implode(', ', $unsupported_scopes_safe);
             $supported_list = implode(', ', $allowed_scopes_safe);
-            $unsupported_message = __('Unsupported scopes were removed:', 'scouting-openid-connect') . " ${unsupported_list}. " . __('Supported scopes are:', 'scouting-openid-connect') . " ${supported_list}.";
+            $unsupported_message = __('Unsupported scopes were removed:', 'scouting-openid-connect') . " {$unsupported_list}. " . __('Supported scopes are:', 'scouting-openid-connect') . " {$supported_list}.";
 
             add_settings_error(
                 'scouting_oidc_scopes',

--- a/src/user/User.php
+++ b/src/user/User.php
@@ -119,7 +119,7 @@ class User {
         $this->sol_id = sanitize_user($user_json_decoded['member_id'] ?? null);
 
         // Email scope data
-        $this->email = sanitize_email($user_json_decoded['email'] ?? null);s.
+        $this->email = sanitize_email($user_json_decoded['email'] ?? null);
         $this->emailVerified = rest_sanitize_boolean($user_json_decoded['email_verified'] ?? false);
 
         // Profile scope data

--- a/src/user/User.php
+++ b/src/user/User.php
@@ -120,6 +120,8 @@ class User {
 
         // Email scope data
         $this->email = sanitize_email($user_json_decoded['email'] ?? null);
+        // SOL3 currently returns false for email_verified for all users.
+        // Preserve the claim for future compatibility, but do not use it to reject logins.
         $this->emailVerified = rest_sanitize_boolean($user_json_decoded['email_verified'] ?? false);
 
         // Profile scope data

--- a/src/user/User.php
+++ b/src/user/User.php
@@ -205,6 +205,7 @@ class User {
 
         Logger::error(LogComponent::USER, 'Login rejected: existing username is not bound to the OIDC subject', $user_id, $this->sol_id);
         ErrorHandler::redirect_to_login_error('error', __('This SOL ID is already linked to another account.', 'scouting-openid-connect'), 'account_binding_mismatch');
+        return false;
     }
 
     /**

--- a/src/user/User.php
+++ b/src/user/User.php
@@ -23,6 +23,11 @@ class User {
     private $sol_id;
 
     /**
+     * @var string OpenID Connect subject
+     */
+    private $subject;
+
+    /**
      * @var string Email address
      */
     private $email;
@@ -117,6 +122,8 @@ class User {
         // Required scopes data
         // Membership scope data
         $this->sol_id = sanitize_user($user_json_decoded['member_id'] ?? null);
+        $subject = $user_json_decoded['sub'] ?? '';
+        $this->subject = is_string($subject) ? $subject : '';
 
         // Email scope data
         $this->email = sanitize_email($user_json_decoded['email'] ?? null);
@@ -162,6 +169,11 @@ class User {
             ErrorHandler::redirect_to_login_error('error', __('SOL ID is missing, make sure the "membership" scope is enabled.', 'scouting-openid-connect'), 'sol_id_is_missing');
         }
 
+        if ($this->subject === '') {
+            Logger::error(LogComponent::USER, 'Construction of User object failed: OIDC subject is missing');
+            ErrorHandler::redirect_to_login_error('error', __('OpenID Connect subject is missing.', 'scouting-openid-connect'), 'subject_is_missing');
+        }
+
         // Validate email is present
         if (empty($this->email)) {
             // Log only which claims are present/absent — never dump personal claim values
@@ -177,7 +189,22 @@ class User {
      * @return bool True if user exists, false otherwise
      */
     public function scouting_oidc_user_check_if_exist(): bool {
-        return username_exists($this->sol_id) !== false;
+        $user_id = username_exists($this->sol_id);
+        if ($user_id === false) {
+            return false;
+        }
+
+        $stored_subject = get_user_meta($user_id, 'scouting_oidc_subject', true);
+        $is_oidc_user = get_user_meta($user_id, 'scouting_oidc_user', true) === 'true';
+        $subject_matches = is_string($stored_subject) && $stored_subject !== '' && hash_equals($stored_subject, $this->subject);
+
+        // Existing plugin users without a subject are bound during this login.
+        if ($is_oidc_user && ($stored_subject === '' || $subject_matches)) {
+            return true;
+        }
+
+        Logger::error(LogComponent::USER, 'Login rejected: existing username is not bound to the OIDC subject', $user_id, $this->sol_id);
+        ErrorHandler::redirect_to_login_error('error', __('This SOL ID is already linked to another account.', 'scouting-openid-connect'), 'account_binding_mismatch');
     }
 
     /**
@@ -374,6 +401,7 @@ class User {
         update_user_meta($user_id, 'locale', $this->language);
         update_user_meta($user_id, 'show_admin_bar_front', 'false');
         update_user_meta($user_id, 'scouting_oidc_user', 'true');
+        update_user_meta($user_id, 'scouting_oidc_subject', $this->subject);
 
         if (get_option('scouting_oidc_user_display_name')) {
             switch (get_option('scouting_oidc_user_display_name')) {

--- a/src/user/User.php
+++ b/src/user/User.php
@@ -119,9 +119,7 @@ class User {
         $this->sol_id = sanitize_user($user_json_decoded['member_id'] ?? null);
 
         // Email scope data
-        $this->email = sanitize_email($user_json_decoded['email'] ?? null);
-        // SOL3 currently returns false for email_verified for all users.
-        // Preserve the claim for future compatibility, but do not use it to reject logins.
+        $this->email = sanitize_email($user_json_decoded['email'] ?? null);s.
         $this->emailVerified = rest_sanitize_boolean($user_json_decoded['email_verified'] ?? false);
 
         // Profile scope data

--- a/src/utilities/ErrorHandler.php
+++ b/src/utilities/ErrorHandler.php
@@ -38,6 +38,10 @@ class ErrorHandler {
      * @return void
      */
     public static function redirect_to_login_error(string $error_description, string $hint, string $message, ?string $error = null): void {
+        if (headers_sent()) {
+            wp_die(esc_html($hint));
+        }
+
         wp_safe_redirect(self::login_error_url($error_description, $hint, $message, $error));
         exit;
     }

--- a/src/utilities/ErrorHandler.php
+++ b/src/utilities/ErrorHandler.php
@@ -40,6 +40,7 @@ class ErrorHandler {
     public static function redirect_to_login_error(string $error_description, string $hint, string $message, ?string $error = null): void {
         if (headers_sent()) {
             wp_die(esc_html($hint));
+            exit;
         }
 
         wp_safe_redirect(self::login_error_url($error_description, $hint, $message, $error));

--- a/uninstall.php
+++ b/uninstall.php
@@ -29,10 +29,11 @@ foreach ($scouting_oidc_options as $scouting_oidc_option) {
     delete_option($scouting_oidc_option);
 }
 
-// Delete issuer-scoped transient rows (e.g. scouting_oidc_wk_<hash>, scouting_oidc_jwks_<hash>)
+// Delete plugin transient rows.
 $scouting_oidc_transient_prefixes = array(
     'scouting_oidc_wk_',
     'scouting_oidc_jwks_',
+    'scouting_oidc_session_',
 );
 
 // Build LIKE patterns for both transient and transient_timeout rows for each prefix to delete all relevant transients in a single query for scalability.
@@ -54,6 +55,7 @@ $wpdb->query($wpdb->prepare($scouting_oidc_delete_transients_sql, $scouting_oidc
 // Delete user meta
 $scouting_oidc_metas = array(
     'scouting_oidc_user',
+    'scouting_oidc_subject',
     'scouting_oidc_birthdate',
     'scouting_oidc_gender',
     'scouting_oidc_phone_number',


### PR DESCRIPTION
This pull request introduces several security and correctness improvements around session handling, OpenID Connect subject binding, and user account management. The main changes include implementing secure host-only session cookies, rotating the session ID after authentication, and enforcing a strict binding between WordPress users and their OpenID Connect subject. Additionally, the uninstall process now cleans up new session and user meta fields.

**Session Security and Management:**

* Switched to a secure, host-only session cookie (`__Host-scouting_oidc_session`), improved session ID generation and validation, and added a method to rotate the session ID after authentication to mitigate session fixation risks. (`src/auth/Session.php` [[1]](diffhunk://#diff-4e9c7925ebce13068494ae6596f06b851acb999d61e495f1f5b3e3023786e0cfR12-R13) [[2]](diffhunk://#diff-4e9c7925ebce13068494ae6596f06b851acb999d61e495f1f5b3e3023786e0cfL48-R72) [[3]](diffhunk://#diff-4e9c7925ebce13068494ae6596f06b851acb999d61e495f1f5b3e3023786e0cfL76-R107)
* Ensured session ID is regenerated after login state is applied, discarding pre-login session data. (`src/auth/OpenIDConnectClient.php` [src/auth/OpenIDConnectClient.phpR880-R881](diffhunk://#diff-555de8616a6b6a787bcb92ce84c817229364d30567497667c6f36a896fa28978R880-R881))
* Improved redirect URL handling by sanitizing `$_SERVER['REQUEST_URI']` before use. (`src/auth/Auth.php` [[1]](diffhunk://#diff-85b8ac48e5f072540d4194b1db409bfb44fa5675fd6379bbd3473f8803d5b908L116-R116) [[2]](diffhunk://#diff-85b8ac48e5f072540d4194b1db409bfb44fa5675fd6379bbd3473f8803d5b908L177-R177)

**User Account Binding and Validation:**

* Added a `subject` property to the `User` class to store the OpenID Connect subject, enforced that it must be present, and updated user meta with this subject on login. (`src/user/User.php` [[1]](diffhunk://#diff-2574f21674fe9059ad7b031441bb50ccc1be68f55a29f2261b7231dd244f1653R25-R29) [[2]](diffhunk://#diff-2574f21674fe9059ad7b031441bb50ccc1be68f55a29f2261b7231dd244f1653R125-R126) [[3]](diffhunk://#diff-2574f21674fe9059ad7b031441bb50ccc1be68f55a29f2261b7231dd244f1653R172-R176) [[4]](diffhunk://#diff-2574f21674fe9059ad7b031441bb50ccc1be68f55a29f2261b7231dd244f1653R404)
* Enhanced the user existence check to require that the WordPress user is either unbound or bound to the same OIDC subject, preventing account takeovers or mismatches. (`src/user/User.php` [src/user/User.phpL180-R207](diffhunk://#diff-2574f21674fe9059ad7b031441bb50ccc1be68f55a29f2261b7231dd244f1653L180-R207))

**Cleanup and Uninstall Enhancements:**

* Updated the uninstall script to remove new session transients and the `scouting_oidc_subject` user meta field. (`uninstall.php` [[1]](diffhunk://#diff-445f7da6877bb1dda2e959aa7e2bfe91657e7738aca6c2e4337238f612e7865bL32-R36) [[2]](diffhunk://#diff-445f7da6877bb1dda2e959aa7e2bfe91657e7738aca6c2e4337238f612e7865bR58)

**Other Minor Improvements:**

* Fixed a string interpolation bug in the OIDC scopes sanitization message. (`src/settings/Oidc.php` [src/settings/Oidc.phpL195-R195](diffhunk://#diff-5af8f457cece6cc2739eb3a211891746fa35c52ada8ece779a92a6accb384756L195-R195))

These changes significantly strengthen authentication security and ensure correct linkage between WordPress accounts and OpenID Connect identities.